### PR TITLE
feat: make Polyphony container isolation the default

### DIFF
--- a/commands/initialize-project.md
+++ b/commands/initialize-project.md
@@ -368,6 +368,22 @@ If creating new:
 
 *Auto-detect using `$BOOTSTRAP_DIR/scripts/detect-agents.sh`. Pre-select based on what's installed. If only Claude is detected, skip this question and default to Claude-only.*
 
+### 10. Enable container isolation for parallel agents? (auto-detect)
+- **Yes** (default if Docker/OrbStack detected) — Each feature agent runs in its own container
+- **No** — Agents share the workspace (native Agent tool)
+
+*Auto-detect Docker/OrbStack. If available, default to Yes and skip this question. Only ask if Docker IS available and you want to confirm, or if Docker is NOT available (inform user and default to No).*
+
+```bash
+if echo "$DETECTED_AGENTS" | grep -qE "docker|orbstack"; then
+    echo "Docker detected — container isolation enabled by default"
+    USE_POLYPHONY="true"
+else
+    echo "Docker not found — agents will share the workspace"
+    USE_POLYPHONY="false"
+fi
+```
+
 ---
 
 ## Phase 4: Execute Setup
@@ -466,6 +482,15 @@ fi
 
 **If AI-first:**
 - Copy `llm-patterns/`
+
+**If container isolation enabled (question 10):**
+- Copy `polyphony/`
+
+```bash
+if [ "$USE_POLYPHONY" = "true" ]; then
+    cp -r ~/.claude/skills/polyphony/ .claude/skills/
+fi
+```
 
 **Note:** Skills are always overwritten with the latest version from ~/.claude/skills/. This ensures updates propagate when user updates their global skills.
 
@@ -1376,6 +1401,91 @@ Cross-Tool Compatibility (if selected):
 
 # Start development
 [appropriate command]
+```
+
+---
+
+## Phase 5b: Polyphony Setup (Container Isolation)
+
+**This phase runs automatically when Docker/OrbStack is detected (question 10) and the user hasn't opted out.**
+
+### Step 1: Check prerequisites
+
+```bash
+# Verify Docker is running
+if echo "$DETECTED_AGENTS" | grep -qE "docker|orbstack"; then
+    docker info &>/dev/null && echo "✓ Docker running" || echo "⚠ Docker installed but not running"
+fi
+
+# Check polyphony CLI
+command -v polyphony &>/dev/null && echo "✓ polyphony CLI available" || echo "⚠ polyphony not on PATH"
+```
+
+### Step 2: Initialize Polyphony config (if missing)
+
+```bash
+if [ ! -d "$HOME/.polyphony" ]; then
+    polyphony init
+    echo "✓ Created ~/.polyphony/ config"
+else
+    echo "✓ ~/.polyphony/ already exists"
+fi
+```
+
+### Step 3: Build worker image (if not present)
+
+```bash
+if ! docker image inspect polyphony-worker:latest &>/dev/null 2>&1; then
+    BOOTSTRAP_DIR=$(cat ~/.claude/.bootstrap-dir 2>/dev/null)
+    if [ -f "$BOOTSTRAP_DIR/templates/Dockerfile.polyphony" ]; then
+        echo "Building polyphony-worker image..."
+        docker build -t polyphony-worker:latest -f "$BOOTSTRAP_DIR/templates/Dockerfile.polyphony" "$BOOTSTRAP_DIR"
+        echo "✓ Built polyphony-worker:latest"
+    fi
+else
+    echo "✓ polyphony-worker:latest image exists"
+fi
+```
+
+### Step 4: Add polyphony skill to project
+
+```bash
+# Copy polyphony skill to project
+cp -r ~/.claude/skills/polyphony/ .claude/skills/
+```
+
+Add to CLAUDE.md Skills section:
+```markdown
+- .claude/skills/polyphony/SKILL.md
+```
+
+Add to CLAUDE.md Cross-Agent Workflow section:
+```markdown
+### Container Isolation (Polyphony)
+When Docker is available, each feature agent runs in its own container with an independent git branch.
+- `/spawn-team` uses Polyphony by default (fallback to native agents if no Docker)
+- `polyphony status` to see running agents
+- `polyphony cleanup` after completion
+```
+
+### Step 5: Show Polyphony status in summary
+
+Add to the Phase 5 summary output:
+```
+Container Isolation (Polyphony):
+✓ Docker/OrbStack detected
+✓ polyphony CLI available
+✓ ~/.polyphony/ config ready
+✓ polyphony-worker:latest image built
+✓ Polyphony skill added to project
+→ /spawn-team will use container isolation by default
+```
+
+**If Docker not available:**
+```
+Container Isolation:
+⚠ Docker not found — /spawn-team will use native agents (shared workspace)
+  Install Docker: brew install --cask docker
 ```
 
 ---

--- a/commands/spawn-team.md
+++ b/commands/spawn-team.md
@@ -8,7 +8,32 @@ Spawn the default agent team for this project. Creates a coordinated team of age
 
 ## Phase 1: Prerequisites Check
 
-### 1.1 Check Agent Definitions
+### 1.1 Detect Container Mode
+
+Check if Polyphony container isolation is available. **Container mode is the default when both Docker and polyphony CLI are present.**
+
+```bash
+BOOTSTRAP_DIR=$(cat ~/.claude/.bootstrap-dir 2>/dev/null)
+DETECTED_AGENTS=$("$BOOTSTRAP_DIR/scripts/detect-agents.sh" 2>/dev/null || echo "claude")
+
+CONTAINER_MODE="false"
+if echo "$DETECTED_AGENTS" | grep -qE "docker|orbstack"; then
+    if command -v polyphony &>/dev/null; then
+        CONTAINER_MODE="true"
+        echo "✓ Container mode: ON (Docker + polyphony detected)"
+        echo "  Each feature agent will run in its own isolated container"
+    else
+        echo "⚠ Docker found but polyphony CLI missing"
+        echo "  Run: cd \$(cat ~/.claude/.bootstrap-dir) && ./install.sh"
+        echo "  Falling back to native agents (shared workspace)"
+    fi
+else
+    echo "ℹ Docker not found — using native agents (shared workspace)"
+    echo "  Install Docker for container isolation: brew install --cask docker"
+fi
+```
+
+### 1.2 Check Agent Definitions
 
 Verify `.claude/agents/` exists and has the required agent definitions:
 
@@ -29,7 +54,7 @@ If missing, copy from the agent-teams skill:
 cp -r ~/.claude/skills/agent-teams/agents/ .claude/agents/
 ```
 
-### 1.2 Check Feature Specs
+### 1.3 Check Feature Specs
 
 ```bash
 ls _project_specs/features/
@@ -43,7 +68,7 @@ If no feature specs exist, ask the user:
 
 For each feature the user lists, create `_project_specs/features/{feature-name}.md` with a skeleton spec.
 
-### 1.3 Check GitHub CLI
+### 1.4 Check GitHub CLI
 
 ```bash
 gh auth status
@@ -51,11 +76,28 @@ gh auth status
 
 Needed by the merger agent for PR creation. Warn if not authenticated but don't block.
 
+### 1.5 Ensure Worker Image (container mode only)
+
+```bash
+if [ "$CONTAINER_MODE" = "true" ]; then
+    if ! docker image inspect polyphony-worker:latest &>/dev/null 2>&1; then
+        echo "Building polyphony-worker image..."
+        docker build -t polyphony-worker:latest \
+            -f "$BOOTSTRAP_DIR/templates/Dockerfile.polyphony" "$BOOTSTRAP_DIR"
+        echo "✓ Built polyphony-worker:latest"
+    else
+        echo "✓ polyphony-worker:latest image ready"
+    fi
+fi
+```
+
 ---
 
 ## Phase 2: Spawn Default Agents
 
-Spawn the 5 permanent agents. Each agent reads `.claude/agents/{type}.md` for its full definition including frontmatter (tools, model, maxTurns, etc.).
+Spawn the 5 permanent agents **natively** (these are coordination agents — they read/verify, not write code). Each agent reads `.claude/agents/{type}.md` for its full definition including frontmatter (tools, model, maxTurns, etc.).
+
+> **Note:** Permanent agents always run natively regardless of container mode. Only feature agents get containers.
 
 ### 2.1 Team Lead
 ```
@@ -101,7 +143,32 @@ Agent tool:
 
 ## Phase 3: Spawn Feature Agents
 
+### Container Mode (default when Docker + polyphony available)
+
 For each feature spec in `_project_specs/features/`:
+
+```bash
+# Polyphony creates a container with its own git clone + branch,
+# then starts the agent CLI inside
+polyphony spawn "{feature-name}: implement feature per _project_specs/features/{feature-name}.md" \
+    --type feature --risk low
+```
+
+This does everything in one command:
+1. Creates a task in Polyphony's store
+2. Routes it to an agent via the routing policy
+3. Provisions a Docker container with a full git clone
+4. Creates a feature branch (`feature/{feature-name}`)
+5. Starts the agent CLI inside the container
+
+Check running containers:
+```bash
+polyphony status
+```
+
+### Fallback Mode (no Docker)
+
+If container mode is not available, spawn feature agents natively (shared workspace):
 
 ```
 Agent tool:
@@ -110,15 +177,51 @@ Agent tool:
   prompt: "You are the feature agent for {feature-name}. Read .claude/agents/feature.md for your instructions. Your feature spec is at _project_specs/features/{feature-name}.md. Start by checking TaskList for your first task."
 ```
 
+> **Advisory:** Running without container isolation (Docker not found). Agents share the workspace — coordinate carefully to avoid file conflicts.
+
 ---
 
 ## Phase 4: Team Status Summary
 
 Show the user:
 
+### Container Mode:
 ```
-AGENT TEAM DEPLOYED
-───────────────────
+AGENT TEAM DEPLOYED (Container Isolation ON)
+─────────────────────────────────────────────
+
+Team: {project-name}
+Features: {N}
+Isolation: Polyphony containers (each feature has its own branch)
+
+NATIVE AGENTS (coordination)
+─────────────────────────────
+  Team Lead        Orchestrating
+  Quality Agent    Watching for verification tasks
+  Security Agent   Watching for security scan tasks
+  Code Review      Watching for review tasks
+  Merger Agent     Watching for branch/PR tasks
+
+CONTAINER AGENTS (isolated)
+────────────────────────────
+  feature-{name1}  Container running — branch: feature/{name1}
+  feature-{name2}  Container running — branch: feature/{name2}
+
+PIPELINE (per feature)
+──────────────────────
+Spec > Review > Tests > RED Verify > Implement >
+GREEN Verify > Validate > Code Review > Security > Branch+PR
+
+Monitor: polyphony status
+Cleanup: polyphony cleanup (after all PRs created)
+```
+
+### Fallback Mode:
+```
+AGENT TEAM DEPLOYED (Shared Workspace)
+───────────────────────────────────────
+
+⚠ Docker not available — agents share the workspace
 
 Team: {project-name}
 Features: {N}
@@ -147,8 +250,17 @@ The team runs autonomously until all PRs are created.
 ## Monitoring
 
 After the team is spawned, the user can:
-- **Check progress:** Ask team lead for status
+- **Check progress:** Ask team lead for status, or run `polyphony status` (container mode)
 - **Message agents:** Use SendMessage to contact any agent
+- **View container logs:** `docker logs polyphony-{feature-name}` (container mode)
 - **Handle blockers:** Message the blocked agent or team lead
 
 The team runs autonomously until all PRs are created, then the team lead shuts everything down.
+
+### Cleanup (container mode)
+
+After all PRs are created:
+```bash
+polyphony cleanup
+```
+This removes completed containers and workspaces. Branches and PRs are preserved on the remote.

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_DIR="$HOME/.claude"
 
-echo "Installing Claude Bootstrap v3.6.0..."
+echo "Installing Claude Bootstrap v4.0.0..."
 echo ""
 
 # Save bootstrap directory location for other scripts
@@ -107,6 +107,30 @@ chmod +x "$CLAUDE_DIR/install-hooks.sh" 2>/dev/null || true
 cp "$SCRIPT_DIR/scripts/install-graph-tools.sh" "$CLAUDE_DIR/" 2>/dev/null || true
 chmod +x "$CLAUDE_DIR/install-graph-tools.sh" 2>/dev/null || true
 
+# Install Polyphony CLI shim
+POLYPHONY_SRC="$SCRIPT_DIR/scripts/polyphony"
+if [ -f "$POLYPHONY_SRC/__main__.py" ]; then
+    INSTALL_DIR="$HOME/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+    cat > "$INSTALL_DIR/polyphony" << SHIM
+#!/bin/bash
+exec python3 -c "import sys; sys.path.insert(0, '$SCRIPT_DIR/scripts'); from polyphony.__main__ import main; sys.exit(main())" "\$@"
+SHIM
+    chmod +x "$INSTALL_DIR/polyphony"
+    echo ""
+    echo "✓ Installed polyphony CLI shim"
+
+    # Create default config if missing
+    if [ ! -d "$HOME/.polyphony" ]; then
+        mkdir -p "$HOME/.polyphony"
+        cp -n "$SCRIPT_DIR/templates/polyphony-config.yaml" "$HOME/.polyphony/config.yaml" 2>/dev/null || true
+        cp -n "$SCRIPT_DIR/templates/polyphony-identities.yaml" "$HOME/.polyphony/identities.yaml" 2>/dev/null || true
+        cp -n "$SCRIPT_DIR/templates/polyphony-agents.yaml" "$HOME/.polyphony/agents.yaml" 2>/dev/null || true
+        cp -n "$SCRIPT_DIR/templates/polyphony-routing.yaml" "$HOME/.polyphony/routing.yaml" 2>/dev/null || true
+        echo "✓ Created ~/.polyphony/ config"
+    fi
+fi
+
 # Run validation
 echo ""
 echo "Running validation..."
@@ -122,14 +146,14 @@ fi
 
 echo ""
 echo "================================================================"
-echo "  Installation complete! (v3.6.0)"
+echo "  Installation complete! (v4.0.0)"
 echo "================================================================"
 echo ""
-echo "What's new in v3.6.0:"
+echo "What's new in v4.0.0:"
+echo "  - Polyphony: container-isolated parallel agents (Docker/OrbStack)"
+echo "  - /spawn-team now uses Polyphony by default (fallback to native)"
+echo "  - polyphony CLI: init, spawn, status, cleanup"
 echo "  - Cross-tool support: Claude Code + Kimi CLI + Codex CLI"
-echo "  - AGENTS.md template for Codex compatibility"
-echo "  - config.toml hooks for Kimi/Codex compatibility"
-echo "  - /sync-agents command for cross-tool sync"
 echo ""
 echo "Usage:"
 echo "  1. Open any project folder"
@@ -137,11 +161,31 @@ echo "  2. Run: claude (or kimi, or codex)"
 echo "  3. Type: /initialize-project"
 echo ""
 echo "Commands installed:"
-echo "  /initialize-project   - Full project setup"
-echo "  /spawn-team           - Spawn agent team"
+echo "  /initialize-project   - Full project setup (includes Polyphony)"
+echo "  /spawn-team           - Spawn agent team (containers by default)"
 echo "  /sync-agents          - Sync config between Claude/Kimi/Codex"
 echo "  /check-contributors   - Team coordination"
 echo "  /update-code-index    - Regenerate code index"
+echo ""
+echo "Polyphony CLI:"
+echo "  polyphony init        - Create ~/.polyphony/ config"
+echo "  polyphony spawn       - Create and route a task"
+echo "  polyphony status      - Show task states"
+echo "  polyphony cleanup     - Remove completed workspaces"
+echo ""
+echo "Container isolation (Polyphony):"
+if echo "$DETECTED_AGENTS" | grep -q "docker"; then
+    echo "  [OK] Docker    - container isolation available"
+elif echo "$DETECTED_AGENTS" | grep -q "orbstack"; then
+    echo "  [OK] OrbStack  - container isolation available"
+else
+    echo "  [--] Docker    - not found (brew install --cask docker)"
+fi
+if echo "$DETECTED_AGENTS" | grep -q "polyphony"; then
+    echo "  [OK] Polyphony - CLI installed"
+else
+    echo "  [--] Polyphony - CLI shim not on PATH (add ~/.local/bin to PATH)"
+fi
 echo ""
 echo "Cross-tool compatibility:"
 if echo "$DETECTED_AGENTS" | grep -q "kimi"; then

--- a/scripts/detect-agents.sh
+++ b/scripts/detect-agents.sh
@@ -34,6 +34,13 @@ main() {
     detect_tool "claude" "claude" "$HOME/.claude"
     detect_tool "kimi" "kimi" "$HOME/.kimi"
     detect_tool "codex" "codex" "$HOME/.codex"
+
+    # Container runtime
+    command -v docker &>/dev/null && echo "docker" || true
+    command -v orbctl &>/dev/null && echo "orbstack" || true
+
+    # Polyphony orchestrator
+    command -v polyphony &>/dev/null && echo "polyphony" || true
 }
 
 main

--- a/skills/agent-teams/SKILL.md
+++ b/skills/agent-teams/SKILL.md
@@ -411,11 +411,39 @@ For existing projects: run `/spawn-team` to spawn the team from existing feature
 
 ---
 
+## Container Isolation (Polyphony)
+
+When Docker/OrbStack is available, feature agents run in Polyphony containers by default. The team lead and shared agents (quality, security, review, merger) still run natively — they only read and coordinate.
+
+### What changes with Polyphony
+
+| Aspect | Without Polyphony | With Polyphony |
+|--------|-------------------|----------------|
+| Feature agents | Shared filesystem | Own container + git branch |
+| File conflicts | Team lead must serialize | Impossible (isolated clones) |
+| Test execution | Shared, can interfere | Independent per container |
+| Branch strategy | Merger agent creates branches | Each container has its own branch |
+
+### How it works
+
+1. `/spawn-team` detects Docker + polyphony CLI
+2. For each feature, runs `polyphony spawn "$FEATURE" --type feature`
+3. Polyphony creates a container with its own git clone + branch
+4. Agent CLI starts inside the container
+5. On completion, changes are on a dedicated branch ready for PR
+
+### Fallback
+
+If Docker is not available, `/spawn-team` falls back to the native Agent tool (shared filesystem). A note is printed:
+> "Running without container isolation (Docker not found). Agents share the workspace."
+
+---
+
 ## Limitations
 
 - **Experimental feature** - Agent teams require the experimental env var
 - **No nested teams** - Teammates cannot spawn sub-teams
 - **One team per session** - Clean up before starting a new team
 - **No session resumption** - If session dies, re-run `/spawn-team` (tasks persist)
-- **File conflicts** - Features sharing files must be serialized by team lead
+- **File conflicts** - Features sharing files must be serialized by team lead (unless using Polyphony containers)
 - **Token cost** - Each agent is a separate Claude instance (5 + N instances)

--- a/skills/polyphony/SKILL.md
+++ b/skills/polyphony/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: polyphony
 description: Multi-agent orchestration with container-isolated workspaces — each agent session runs in its own Docker container with independent git branches
-when-to-use: When running multiple AI agents on the same codebase in parallel, or when tasks need container isolation
+when-to-use: Always loaded when container isolation is available (Docker/OrbStack installed). Default for /spawn-team.
 user-invocable: false
 effort: high
 ---

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -18,6 +18,7 @@ You are a brilliant engineer who also happens to be genuinely funny. Think dry w
 @.claude/skills/security/SKILL.md
 @.claude/skills/mnemos/SKILL.md
 @.claude/skills/cross-agent-delegation/SKILL.md
+@.claude/skills/polyphony/SKILL.md
 
 ## Project Context
 - Language: [e.g., TypeScript]
@@ -72,6 +73,12 @@ Claude orchestrates Kimi delegation automatically:
 - Blast radius 4-8 files: Claude asks user, then delegates or handles directly
 - Blast radius > 8 files: Claude handles it (needs full context)
 Context is passed via `mnemos checkpoint` + `mnemos resume` (not raw conversation).
+
+### Container Isolation (Polyphony)
+When Docker is available, each feature agent runs in its own container with an independent git branch.
+- `/spawn-team` uses Polyphony by default (fallback to native agents if no Docker)
+- `polyphony status` to see running agents
+- `polyphony cleanup` after completion
 
 ### iCPG (Always-On for All Agents)
 Before ANY code change in ANY tool (Claude, Kimi, Codex):

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -29,7 +29,11 @@
       "Bash(icpg *)",
       "Bash(python -m icpg *)",
       "Bash(mnemos *)",
-      "Bash(python -m mnemos *)"
+      "Bash(python -m mnemos *)",
+      "Bash(polyphony *)",
+      "Bash(python -m polyphony *)",
+      "Bash(docker ps *)",
+      "Bash(docker logs *)"
     ],
     "deny": [
       "Bash(rm -rf *)",

--- a/tests/test_cross_agent.py
+++ b/tests/test_cross_agent.py
@@ -67,13 +67,12 @@ class TestCrossAgentDelegation:
         assert "mnemos add goal" in content
         assert "mnemos checkpoint" in content
 
-    def test_skill_has_blast_radius_rules(self) -> None:
+    def test_skill_has_complexity_scoring_rules(self) -> None:
         path = REPO_ROOT / "skills" / "cross-agent-delegation" / "SKILL.md"
         content = path.read_text()
-        assert "Blast Radius" in content or "blast radius" in content
-        assert "1-3 files" in content
-        assert "4-8 files" in content
-        assert "9+ files" in content
+        assert "0-3" in content
+        assert "4-6" in content
+        assert "7-10" in content
 
     def test_skill_has_tool_detection(self) -> None:
         path = REPO_ROOT / "skills" / "cross-agent-delegation" / "SKILL.md"

--- a/tests/test_cross_tool.py
+++ b/tests/test_cross_tool.py
@@ -28,7 +28,7 @@ class TestDetectAgents:
             timeout=10,
         )
         assert result.returncode == 0
-        valid_tools = {"claude", "kimi", "codex"}
+        valid_tools = {"claude", "kimi", "codex", "docker", "orbstack", "polyphony"}
         for line in result.stdout.strip().splitlines():
             assert line in valid_tools
 


### PR DESCRIPTION
## Summary
- **install.sh** now creates the `polyphony` CLI shim at `~/.local/bin/` and bootstraps `~/.polyphony/` config (v4.0.0)
- **/initialize-project** auto-detects Docker, sets up Polyphony (Phase 5b), builds worker image, copies skill
- **/spawn-team** uses `polyphony spawn` for feature agents by default; coordination agents (team-lead, quality, security, review, merger) stay native. Falls back to shared-workspace Agent tool if Docker is missing
- **detect-agents.sh** now reports docker, orbstack, polyphony alongside claude/kimi/codex
- **settings.json** adds polyphony + docker permissions
- **agent-teams SKILL.md** documents container isolation with comparison table and fallback behavior
- **templates/CLAUDE.md** references polyphony skill and container workflow
- Fixed stale test for complexity scoring (was checking old "1-3 files" wording)

## Test plan
- [x] All 235 tests pass (`pytest tests/ -q`)
- [ ] `./install.sh` creates polyphony shim at `~/.local/bin/polyphony`
- [ ] `polyphony --version` returns `polyphony 0.1.0`
- [ ] `/initialize-project` detects Docker and offers container isolation
- [ ] `/spawn-team` with Docker uses `polyphony spawn` for features
- [ ] `/spawn-team` without Docker falls back to native agents with advisory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released v4.0.0
  * Container isolation for feature agents using Docker/OrbStack and Polyphony
  * Automatic detection of containerization tools with intelligent fallback to native execution

* **Documentation**
  * Refreshed initialization and team-spawning workflows to support container mode
  * Enhanced coordination skill documentation with container isolation guidance

* **Tests**
  * Expanded test coverage for tool detection and agent complexity scoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->