### PR TITLE
fix: env-var configurable Ollama model + host (default to publicly-available qwen2.5-coder:3b)

### DIFF
--- a/bin/qwen3
+++ b/bin/qwen3
@@ -1,4 +1,9 @@
 #!/bin/bash
-curl -s http://localhost:11434/api/chat \
-  -d "{\"model\": \"qwen3-coder:30b-a3b-q8_0\", \"messages\": [{\"role\": \"user\", \"content\": $(echo "$1" | jq -Rs .)}], \"stream\": false, \"options\": {\"temperature\": 0.3}}" \
+# Ollama qwen executor. Model + host are env-var configurable so the script
+# works regardless of which qwen variant is pulled and whether Ollama runs
+# locally or on a remote (e.g. Tailscale) host.
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5-coder:3b}"
+OLLAMA_BASE="${OLLAMA_BASE:-http://localhost:11434}"
+curl -s "${OLLAMA_BASE}/api/chat" \
+  -d "{\"model\": \"${OLLAMA_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": $(echo "$1" | jq -Rs .)}], \"stream\": false, \"options\": {\"temperature\": 0.3}}" \
   | jq -r '.message.content'

--- a/hooks/auto-review-hook
+++ b/hooks/auto-review-hook
@@ -55,10 +55,13 @@ DECISION=""
 CLASSIFIER=""
 
 # Level 1: qwen3 via Ollama (free, local)
-if [ -z "$DECISION" ] && curl -s --connect-timeout 2 http://localhost:11434/api/tags >/dev/null 2>&1; then
+# Model + host env-var configurable (see bin/qwen3 for the matching pattern).
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5-coder:3b}"
+OLLAMA_BASE="${OLLAMA_BASE:-http://localhost:11434}"
+if [ -z "$DECISION" ] && curl -s --connect-timeout 2 "${OLLAMA_BASE}/api/tags" >/dev/null 2>&1; then
   CONTENT=$(echo "$CLASSIFY_PROMPT" | jq -Rs .)
-  DECISION=$(curl -s --max-time 6 http://localhost:11434/api/chat \
-    -d "{\"model\": \"qwen3-coder:30b-a3b-q8_0\", \"messages\": [{\"role\": \"user\", \"content\": ${CONTENT}}], \"stream\": false, \"options\": {\"temperature\": 0.1, \"num_predict\": 20}}" \
+  DECISION=$(curl -s --max-time 6 "${OLLAMA_BASE}/api/chat" \
+    -d "{\"model\": \"${OLLAMA_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": ${CONTENT}}], \"stream\": false, \"options\": {\"temperature\": 0.1, \"num_predict\": 20}}" \
     2>/dev/null | jq -r '.message.content // ""' | head -1 || true)
   [ -n "$DECISION" ] && CLASSIFIER="qwen3"
 fi

--- a/hooks/route-task-hook
+++ b/hooks/route-task-hook
@@ -58,10 +58,14 @@ _classify_parse() {
 }
 
 # Level 1: qwen3 via Ollama (free, local)
-if curl -s --connect-timeout 2 http://localhost:11434/api/tags >/dev/null 2>&1; then
+# Model + host are env-var configurable; defaults work on any machine with
+# Ollama installed and `ollama pull qwen2.5-coder:3b` run.
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5-coder:3b}"
+OLLAMA_BASE="${OLLAMA_BASE:-http://localhost:11434}"
+if curl -s --connect-timeout 2 "${OLLAMA_BASE}/api/tags" >/dev/null 2>&1; then
   CONTENT=$(echo "$CLASSIFY_PROMPT" | jq -Rs .)
-  RAW=$(curl -s --max-time 8 http://localhost:11434/api/chat \
-    -d "{\"model\": \"qwen3-coder:30b-a3b-q8_0\", \"messages\": [{\"role\": \"user\", \"content\": ${CONTENT}}], \"stream\": false, \"options\": {\"temperature\": 0.1, \"num_predict\": 40}}" \
+  RAW=$(curl -s --max-time 8 "${OLLAMA_BASE}/api/chat" \
+    -d "{\"model\": \"${OLLAMA_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": ${CONTENT}}], \"stream\": false, \"options\": {\"temperature\": 0.1, \"num_predict\": 40}}" \
     2>/dev/null | jq -r '.message.content // ""' | head -1 || true)
   if _classify_parse "$RAW"; then
     CLASSIFIER_USED="qwen3"


### PR DESCRIPTION
## Problem

The qwen executor `bin/qwen3` and the L1 classifiers in `hooks/route-task-hook` + `hooks/auto-review-hook` hardcoded:

- `model = qwen3-coder:30b-a3b-q8_0`
- `host  = http://localhost:11434`

The model tag is not in [Ollama's public library](https://ollama.com/library) — a fresh-install user running `ollama pull qwen3-coder:30b-a3b-q8_0` per the docs gets nothing back. Net effect: the L1 (free, local) classifier tier silently fails on every machine but the maintainer's, and the routing cascade always falls through to kimi (L2) or deepseek-flash (L3).

## Fix

Two env vars with sensible defaults:

| Var | Default | Notes |
|---|---|---|
| `OLLAMA_MODEL` | `qwen2.5-coder:3b` | ~1.9 GB, in Ollama's library, fits any machine |
| `OLLAMA_BASE`  | `http://localhost:11434` | Override for remote Ollama (e.g. Tailscale node) |

## Verification

```
$ OLLAMA_MODEL=qwen2.5-coder:3b ./bin/qwen3 "Reply with exactly: ENV_VAR_PATH_OK"
ENV_VAR_PATH_OK

$ unset OLLAMA_MODEL; ./bin/qwen3 "Reply with exactly: DEFAULT_PATH_OK"
DEFAULT_PATH_OK
```

`bash -n` syntax-check passes on all three files.

## Test plan
- [ ] On a fresh-clone macOS install, `ollama pull qwen2.5-coder:3b && ./bin/qwen3 "what is 2+2"` returns `4` — currently this fails because the default model is unpullable.
- [ ] `OLLAMA_BASE=http://remote-tailscale-ip:11434 ./bin/qwen3 "..."` hits the remote daemon when set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama integration is now configurable via environment variables. Set `OLLAMA_MODEL` (defaults to `qwen2.5-coder:3b`) and `OLLAMA_BASE` (defaults to `http://localhost:11434`) to customize your AI classifier deployment across review and task routing automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alinaqi/maggy/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->