### PR TITLE
feat(maggy): agentic council PR reviewer + extensible language skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You're using Claude Code. It's impressive — but:
 | **Cortex MCP** | Code intelligence: 10 edge types, cyclomatic complexity, FTS5 search, bidirectional traversal. 15 tools, single SQLite DB. [Benchmarks](cortex-mcp/docs/cortex-vs-codebase-memory.md) |
 | **Polyphony** | Docker-isolated parallel agent execution. Second session auto-provisions a workspace. [Spec](maggy/docs/polyphony-spec.md) |
 | **Engram** | Cross-session memory. 7 amnesia types. Persists architectural knowledge across weeks |
+| **Council PR Review** | Multi-model council reviews a GitHub PR from the dashboard — deterministic mega-PR chunking, a static gate (tsc/ruff) as ground truth, and an adversarial refute pass that kills false positives. Extensible per-language skills (Python/TS/Go/Rust/Java/C#/Ruby/PHP + drop-in more). `pip install maggy-harness[review]` |
 | **Plugins** | Drop-in system. Ships with: Build-in-Public (auto-posts to LinkedIn/X), Telos, GitHub/Asana/Monday providers |
 
 ---

--- a/maggy/CHANGELOG.md
+++ b/maggy/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to Maggy will be documented in this file.
 
 ---
 
+## [6.51.0] - 2026-06-20
+
+### Agentic council PR reviewer — `maggy.review`
+
+A multi-model "council" reviews a GitHub PR and posts a CodeRabbit-style review
+with inline comments. It plans the review from blast radius, deterministically
+chunks mega-PRs (every model call sees a bounded slice), reviews each chunk with
+a rotating panel of tool-using agents, runs a deterministic static gate
+(tsc/ruff) as ground truth, then adversarially refutes blocking findings to kill
+false positives.
+
+#### Added
+- **`maggy/review/` module** — vendored the council pipeline (planner, reviewers,
+  chair, refuter, GitHub I/O, static gate). Pydantic structured outputs;
+  per-finding evidence required for blockers. (The functional-test/provision
+  harness is intentionally not vendored — it boots untrusted app code.)
+- **Extensible language skills** (`review/languages.py`) — a registry maps a
+  language to its file extensions/path-markers + a skill file. Adding a language
+  needs **no core change**: drop `review/skills/<lang>.md` and
+  `register_language(...)`, or declare it under `review.languages` in config.
+  Seeds the common set — **go, rust, java, csharp, ruby, php** — alongside
+  python/typescript/db.
+- **Configurable GitHub token** — resolution is per-request override →
+  `review.github_token` (config) → `GITHUB_TOKEN` (env). New `ReviewConfig`
+  section. The token is never returned by `/api/config` or `/api/pr-review/status`.
+- **API** — `/api/pr-review/{status,languages,run}`. The heavy pipeline is an
+  optional extra (`pip install maggy-harness[review]`) imported lazily; `/run`
+  returns 503 with an install hint when it's absent.
+- **Dashboard** — a **PR Review** tab: repo + PR#, optional token/checkout path,
+  dry-run toggle, live model/token/language status, and a rendered verdict with
+  findings, cost, and run log.
+- 32 tests (registry detection/loading/extensibility, token resolution order,
+  vendored pure functions, route status codes). ruff + mypy clean.
+
+#### Security
+- Hardened the reviewer's shell-outs against argv flag-smuggling: `grep`
+  (model-controlled pattern) and `ruff` (PR-controlled filenames) now use a `--`
+  option terminator and reject leading-dash values.
+
+#### Fixed
+- `valid_comment_lines` counted `\ No newline at end of file` diff markers as
+  real lines, shifting inline-comment positions. (Found by dogfooding the council
+  on its own PR.)
+- The `[review]` extra now declares the provider SDKs (`google-genai`, `openai`)
+  the default roster needs — it previously failed at runtime with
+  `Unknown provider: google`.
+
 ## [6.50.0] - 2026-06-11
 
 ### PyPI packaging — `pip install maggy-harness`

--- a/maggy/README.md
+++ b/maggy/README.md
@@ -12,6 +12,7 @@ Chat with your codebases across Claude, Codex, and Kimi — with semantic routin
 - **Parallel Execution** — Polyphony container orchestration for complex tasks (blast>=7)
 - **AI-prioritized Tasks** — ranks open issues by urgency + OKR alignment
 - **One-click Execute** — TDD pipeline with iCPG context enrichment
+- **Council PR Review** — a multi-model council reviews a GitHub PR from the dashboard: deterministic mega-PR chunking, a static gate (tsc/ruff) as ground truth, an adversarial refute pass to kill false positives, and extensible per-language skills (Python/TS/Go/Rust/Java/C#/Ruby/PHP — drop in more). `pip install maggy-harness[review]`
 - **Competitor Intelligence** — auto-discovered competitors, daily AI briefing
 - **Engram Memory** — persistent cross-session memory with amnesia diagnostics
 

--- a/maggy/maggy/api/routes_pr_review.py
+++ b/maggy/maggy/api/routes_pr_review.py
@@ -1,0 +1,109 @@
+"""Agentic council PR review — run the vendored maggy.review pipeline on a GitHub PR.
+
+The heavy pipeline (pydantic-ai + provider SDKs) is an optional extra
+(`pip install maggy-harness[review]`) and is imported lazily, so the lightweight
+endpoints (languages, status) work on a base install. Token resolution order:
+per-request override > Maggy config (review.github_token) > env GITHUB_TOKEN.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from pydantic import BaseModel
+
+from maggy.api.auth import check_auth
+from maggy.review import config as review_config
+from maggy.review import languages as review_languages
+
+router = APIRouter(prefix="/api/pr-review", tags=["pr-review"])
+
+
+class RunRequest(BaseModel):
+    owner: str
+    repo: str
+    pr_number: int
+    dry_run: bool | None = None       # None -> fall back to config.review.default_dry_run
+    github_token: str | None = None   # per-request override (beats config + env)
+    repo_path: str | None = None      # local checkout for the static gate / FP filter
+
+
+def _register_config_languages(cfg) -> None:
+    """Register any user-defined languages from config into the skill registry."""
+    review_languages.load_from_config(getattr(cfg.review, "languages", []))
+
+
+def _resolve_token(cfg, override: str | None) -> str | None:
+    """Per-request override > Maggy config > env GITHUB_TOKEN."""
+    return review_config.resolve_token(override, getattr(cfg.review, "github_token", ""))
+
+
+@router.get("/languages")
+async def list_languages(request: Request, x_api_key: str | None = Header(None)) -> dict:
+    """All languages the reviewer can skill up on (built-ins + config-defined)."""
+    check_auth(request, x_api_key)
+    _register_config_languages(request.app.state.cfg)
+    return {"languages": review_languages.supported()}
+
+
+@router.get("/status")
+async def status(request: Request, x_api_key: str | None = Header(None)) -> dict:
+    """Is the review extra installed? Which model seats + token are available?"""
+    check_auth(request, x_api_key)
+    cfg = request.app.state.cfg
+    try:
+        import pydantic_ai  # noqa: F401
+        installed = True
+    except ImportError:
+        installed = False
+    models = [name for name, _f, _l, _t in review_config.available()] if installed else []
+    return {
+        "installed": installed,
+        "hint": "" if installed else "Install the reviewer: pip install maggy-harness[review]",
+        "models": models,
+        "token_configured": bool(_resolve_token(cfg, None)),
+        "languages": review_languages.supported(),
+    }
+
+
+def _serialize(out: dict) -> dict:
+    """JSON-safe view of run_review's result: verdict + findings + cost + meta."""
+    final = out["final"]
+    plan = out["plan"]
+    return {
+        "decision": final.decision,
+        "summary": final.summary,
+        "findings": [f.model_dump() for f in final.findings],
+        "blast_radius": plan.blast_radius.size,
+        "council": len(out.get("chunks", []) or []),
+        "post": out.get("post"),
+        "cost": out.get("cost"),
+    }
+
+
+@router.post("/run")
+async def run(request: Request, body: RunRequest, x_api_key: str | None = Header(None)) -> dict:
+    """Run the council on a PR. dry_run (default from config) skips the GitHub write."""
+    check_auth(request, x_api_key)
+    cfg = request.app.state.cfg
+    token = _resolve_token(cfg, body.github_token)
+    if not token:
+        raise HTTPException(400, "No GitHub token — set review.github_token, pass github_token, or export GITHUB_TOKEN")
+    try:
+        from maggy.review.pipeline import run_review
+    except ImportError:
+        raise HTTPException(503, "Reviewer not installed — run: pip install maggy-harness[review]")
+
+    _register_config_languages(cfg)
+    dry = cfg.review.default_dry_run if body.dry_run is None else body.dry_run
+    repo_path = body.repo_path or cfg.review.repo_paths.get(f"{body.owner}/{body.repo}")
+    logs: list[str] = []
+    try:
+        out = await run_review(
+            body.owner, body.repo, body.pr_number,
+            dry_run=dry, repo_path=repo_path, on_log=logs.append, token=token,
+        )
+    except SystemExit as exc:        # pipeline raises SystemExit for config problems
+        raise HTTPException(400, str(exc))
+    except Exception as exc:          # noqa: BLE001 — surface the failure, don't 500 opaquely
+        raise HTTPException(502, f"Review failed: {type(exc).__name__}: {exc}")
+    return {"dry_run": dry, **_serialize(out), "logs": logs[-40:]}

--- a/maggy/maggy/config.py
+++ b/maggy/maggy/config.py
@@ -199,6 +199,20 @@ class OrchestratorConfig:
 
 
 @dataclass
+class ReviewConfig:
+    """Config for the agentic council PR reviewer (maggy.review)."""
+    # Default GitHub token for reviews; a per-request override beats this, and
+    # env GITHUB_TOKEN is the final fallback (see review.config.resolve_token).
+    github_token: str = ""
+    # "owner/repo" -> local checkout path, used by the static gate + FP filter.
+    repo_paths: dict[str, str] = field(default_factory=dict)
+    # User-defined languages registered into the skill registry at runtime; each:
+    # {name, extensions:[...], path_markers?:[...], skill_file?}.
+    languages: list[dict] = field(default_factory=list)
+    default_dry_run: bool = True
+
+
+@dataclass
 class MaggyConfig:
     issue_tracker: IssueTrackerConfig = field(default_factory=IssueTrackerConfig)
     codebases: list[CodebaseConfig] = field(default_factory=list)
@@ -214,6 +228,7 @@ class MaggyConfig:
     mesh: MeshConfig = field(default_factory=MeshConfig)
     heartbeat: HeartbeatConfig = field(default_factory=HeartbeatConfig)
     orchestrator: OrchestratorConfig = field(default_factory=OrchestratorConfig)
+    review: ReviewConfig = field(default_factory=ReviewConfig)
 
     def codebase_paths(self) -> dict[str, Path]:
         """Return {key: expanded_path} for all configured codebases."""
@@ -306,6 +321,7 @@ def _from_dict(data: dict[str, Any]) -> MaggyConfig:
         mesh=MeshConfig(**(data.get("mesh") or {})),
         heartbeat=HeartbeatConfig(**(data.get("heartbeat") or {})),
         orchestrator=OrchestratorConfig(**(data.get("orchestrator") or {})),
+        review=ReviewConfig(**(data.get("review") or {})),
     )
 
 

--- a/maggy/maggy/main.py
+++ b/maggy/maggy/main.py
@@ -54,6 +54,7 @@ from maggy.api.routes_pipeline import router as pipeline_router
 from maggy.api.routes_refresh import router as refresh_router
 from maggy.api.routes_shell import router as shell_router
 from maggy.api.routes_srooter import router as srooter_router
+from maggy.api.routes_pr_review import router as pr_review_router
 from maggy.api.routes_approval import router as approval_router
 from maggy.api.routes_models import router as models_router
 from maggy.mesh.ws_server import router as ws_mesh_router
@@ -348,7 +349,7 @@ _ROUTERS = (
     mesh_router, mesh_admin_router, models_router, observability_router,
     orchestrator_router, pipeline_router, planning_router, plugins_router,
     process_router, projects_router, refresh_router, routing_router,
-    setup_router, shell_router, skills_router, srooter_router, system_router, testing_router, users_router,
+    setup_router, shell_router, skills_router, srooter_router, pr_review_router, system_router, testing_router, users_router,
     ws_mesh_router,
 )
 

--- a/maggy/maggy/review/agents.py
+++ b/maggy/maggy/review/agents.py
@@ -1,0 +1,77 @@
+"""The agents: planner (blast radius + council sizing), reviewers, chair."""
+from __future__ import annotations
+
+from pydantic_ai import Agent
+
+from .models import Refutation, ReviewPlan, Verdict
+from .tools import register_tools
+
+REFUTER_PROMPT = """You are a SKEPTICAL verifier. A reviewer flagged a BLOCKING finding. Try HARD
+to DISPROVE it using your tools — grep the BARE symbol/string across the repo (NOT a line-spanning
+pattern like `useEffect.*connect`; grep just `connect(` or the key name), and read the relevant file
+region. Set refuted=true ONLY with concrete evidence the claim is false (cite the grep/read result).
+If you cannot disprove it, set refuted=false — the finding stands.
+
+Common false-positive classes — check these explicitly, because the diff a reviewer sees may be
+TRUNCATED (huge PRs) and mislead them:
+- "i18n / translation key missing" or "lacks German/de translation": OPEN the actual locale files
+  and grep the bare key (its last segment). For this repo they live under
+  libs/shared/services/translate/src/lib/locals/en/en.json and .../de/de.json. If the key (or its
+  i18next plural variants key_one/key_other) exists in BOTH, the finding is FALSE — refuted=true.
+- "new feature not feature-flagged" / "mounts unconditionally": a component being a NEW FILE does
+  NOT mean the feature is new. grep where it's mounted (Router.tsx, route definitions) and check
+  whether that ROUTE already exists on the base branch / is gated upstream. If the route/host
+  predates this PR or the mount is already behind a flag, refuted=true.
+- "symbol never called/defined": grep the bare symbol — if it IS referenced/defined, refuted=true.
+
+A false 'blocking' on a PR is costly, so verify rigorously, but do not let a truncated diff trick
+you into keeping a finding that the real files disprove."""
+
+PLANNER_PROMPT = """You are the review CHAIR PLANNING how to review this PR. Use your tools
+(list_changed_files, get_diff, read_file, grep, read_adr) to understand the change, then
+produce a ReviewPlan:
+
+- blast_radius: impacted_files (what else likely breaks/needs checking), impacted_symbols,
+  impacted_endpoints, cross_service (does it cross a service/bounded-context boundary?),
+  touches_auth_or_data (auth, migrations, money, or PII?), languages (subset of db/python/
+  typescript actually changed), size (small=localized/low-risk, medium, large=wide or risky),
+  and a one-line rationale.
+- council_size: how many reviewer agents to summon, SIZED TO RISK — small=2, medium=3-4,
+  large OR touches_auth_or_data OR cross_service=5(max).
+- rounds: 1 normally; 2 (independent + discussion) for large or auth/data changes.
+- chunks: ONLY for large PRs — split the changed files into coherent review areas (name,
+  focus, files, languages); empty otherwise.
+
+Be decisive and concrete. Use the tools before deciding."""
+
+CHAIR_PROMPT = """You are the review CHAIR synthesizing the council. The individual reviewer
+Verdicts are in the user message. Produce ONE final Verdict:
+- decision: approve | changes_needed.
+- summary: 2-4 sentences for the PR author.
+- findings: a DEDUPED union of the reviewers' findings. KEEP file/line/severity so they post
+  as inline comments. Before keeping a BLOCKING finding, sanity-check it with read_file/grep —
+  DROP any blocking finding that lacks evidence or that you can disprove (e.g. a symbol the
+  reviewer thought was undefined but read_file shows defined). A finding blocks only if THIS
+  diff introduces it; pre-existing debt is a nit.
+Approve only if no real blocking finding remains."""
+
+
+def build_planner(model, with_tools: bool = True):
+    a = Agent(model, output_type=ReviewPlan, retries=3, instructions=PLANNER_PROMPT)
+    return register_tools(a) if with_tools else a
+
+
+def build_reviewer(model, skill: str, focus: str = "", with_tools: bool = True):
+    instr = skill + ("\n\n## This review\n" + focus if focus else "")
+    a = Agent(model, output_type=Verdict, retries=3, instructions=instr)
+    return register_tools(a) if with_tools else a
+
+
+def build_chair(model, skill: str, with_tools: bool = True):
+    a = Agent(model, output_type=Verdict, retries=3, instructions=skill + "\n\n" + CHAIR_PROMPT)
+    return register_tools(a) if with_tools else a
+
+
+def build_refuter(model):
+    a = Agent(model, output_type=Refutation, retries=3, instructions=REFUTER_PROMPT)
+    return register_tools(a)

--- a/maggy/maggy/review/config.py
+++ b/maggy/maggy/review/config.py
@@ -1,0 +1,83 @@
+"""Model roster, cost model, and key/token resolution for the council reviewer.
+
+Adapted from revir for Maggy: provider keys come from the Maggy process
+environment (Maggy already loads its own config/.env into os.environ), the
+GitHub token is resolved from a per-request override / Maggy config / env, and
+``load_skill`` is delegated to the extensible language registry. The model
+ROSTER and pricing are unchanged from revir.
+"""
+from __future__ import annotations
+
+import os
+
+# load_skill lives in the language registry now; re-exported for pipeline compat.
+from .languages import load_skill  # noqa: F401
+
+
+def load_env() -> None:
+    """Normalize provider key aliases. Maggy already populated os.environ from
+    its own config/.env, so there is no revir/.env to read here."""
+    if os.environ.get("XAI_API_KEY") and not os.environ.get("GROK_API_KEY"):
+        os.environ["GROK_API_KEY"] = os.environ["XAI_API_KEY"]
+
+
+def resolve_token(override: str | None = None, config_token: str | None = None) -> str | None:
+    """GitHub token resolution: per-request override > Maggy config > env.
+
+    Returns None when no token is configured anywhere (callers raise a clear
+    error rather than calling GitHub unauthenticated)."""
+    for candidate in (override, config_token, os.environ.get("GITHUB_TOKEN")):
+        if candidate and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def _gpt():
+    from pydantic_ai.models.openai import OpenAIResponsesModel  # gpt-5.5-pro is Responses-only
+    return OpenAIResponsesModel(os.environ.get("OPENAI_REVIEW_MODEL", "gpt-5.5-pro-2026-04-23"))
+
+
+# CS-legend roster: (codename, model-factory, label, required-env-key, tool_capable)
+# tool_capable=False -> reviews tool-lessly (diff embedded in the prompt).
+ROSTER = [
+    ("Lovelace", lambda: "deepseek:deepseek-chat", "DeepSeek", "DEEPSEEK_API_KEY", False),
+    ("Hopper", lambda: "google:gemini-3.1-pro-preview", "Gemini 3.1 Pro", "GEMINI_API_KEY", True),
+    ("Turing", lambda: "grok:grok-3", "Grok 3", "GROK_API_KEY", True),
+    ("Dijkstra", _gpt, "GPT-5.5-pro", "OPENAI_API_KEY", True),
+    ("Knuth", lambda: "google:gemini-3.5-flash", "Gemini 3.5 Flash", "GEMINI_API_KEY", True),
+]
+CHAIR = "Knuth"  # planner + synthesizer (cheap, tool-capable)
+
+
+def available():
+    """Roster entries whose API key is present, as (name, factory, label, tool_capable)."""
+    load_env()
+    out = []
+    for name, factory, label, need, tools in ROSTER:
+        keys = [need] + (["GOOGLE_API_KEY"] if need == "GEMINI_API_KEY" else [])
+        if any(os.environ.get(k) for k in keys):
+            out.append((name, factory, label, tools))
+    return out
+
+
+# approximate public $ per 1M tokens (input, output) — cost estimation only
+PRICING = {
+    "gemini": (0.30, 2.50),
+    "gemini-3.5": (0.50, 3.00),
+    "gemini-3.1-pro": (1.25, 10.00),
+    "deepseek": (0.28, 0.42),
+    "grok": (3.00, 15.00),
+    "gpt-5.5": (15.00, 120.00),
+}
+PRICING_KEY = {"Lovelace": "deepseek", "Hopper": "gemini-3.1-pro", "Turing": "grok",
+               "Dijkstra": "gpt-5.5", "Knuth": "gemini-3.5"}
+
+
+def cost_usd(model_key, input_tokens, output_tokens, cache_read_tokens=0):
+    """Cost in USD. Cached input (implicit caching) billed at ~25% of input rate."""
+    p = PRICING.get(model_key)
+    if not p:
+        return 0.0
+    cached = min(cache_read_tokens or 0, input_tokens)
+    fresh = input_tokens - cached
+    return (fresh / 1e6 * p[0] + cached / 1e6 * p[0] * 0.25 + output_tokens / 1e6 * p[1])

--- a/maggy/maggy/review/github.py
+++ b/maggy/maggy/review/github.py
@@ -1,0 +1,169 @@
+"""GitHub API: fetch PR data + post a review with inline line comments."""
+from __future__ import annotations
+
+import base64
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://api.github.com"
+
+
+def gh(token, path, accept="application/vnd.github+json", method="GET", body=None):
+    req = urllib.request.Request(
+        f"{API}{path}",
+        data=json.dumps(body).encode() if body else None,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": accept,
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "revir-agentic-reviewer",
+            **({"Content-Type": "application/json"} if body else {}),
+        },
+    )
+    with urllib.request.urlopen(req) as r:
+        raw = r.read()
+        return raw if accept.endswith("diff") else json.loads(raw or b"{}")
+
+
+def get_pr(token, owner, repo, num):
+    return gh(token, f"/repos/{owner}/{repo}/pulls/{num}")
+
+
+def get_pr_files(token, owner, repo, num):
+    out, page = [], 1
+    while page <= 40:
+        batch = gh(token, f"/repos/{owner}/{repo}/pulls/{num}/files?per_page=100&page={page}")
+        if not isinstance(batch, list) or not batch:
+            break
+        out.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return out
+
+
+def get_file_at(token, owner, repo, path, ref):
+    d = gh(token, f"/repos/{owner}/{repo}/contents/{urllib.parse.quote(path)}?ref={ref}")
+    return base64.b64decode(d.get("content", "")).decode("utf-8", "replace")
+
+
+def valid_comment_lines(patch: str) -> set[int]:
+    """New-file (RIGHT) line numbers that appear in the diff hunks — the only
+    lines GitHub will accept an inline review comment on."""
+    lines, newno = set(), None
+    for ln in (patch or "").splitlines():
+        h = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@", ln)
+        if h:
+            newno = int(h.group(1))
+            continue
+        if newno is None:
+            continue
+        if ln.startswith("+"):
+            lines.add(newno)
+            newno += 1
+        elif ln.startswith("-"):
+            pass
+        else:
+            newno += 1
+    return lines
+
+
+def _sev(fnd):
+    return getattr(fnd.severity, "value", fnd.severity)
+
+
+# CodeRabbit-style severity badge line per finding
+_BADGE = {
+    "blocking": "_⚠️ Potential issue_ | _🔴 Blocking_",
+    "nit": "_🧹 Nitpick_ | _🟡 Minor_",
+}
+
+
+def _finding_body(fnd):
+    """A single inline comment, formatted like CodeRabbit: badge · bold title ·
+    explanation · collapsible suggested fix · collapsible evidence."""
+    body = f"{_BADGE.get(_sev(fnd), '_💡 Note_')}\n\n**{fnd.title}**\n\n{fnd.detail}"
+    if fnd.suggestion:
+        body += ("\n\n<details>\n<summary>💡 Suggested fix</summary>\n\n"
+                 f"{fnd.suggestion}\n\n</details>")
+    if fnd.evidence:
+        body += ("\n\n<details>\n<summary>🔎 Evidence (what revir verified)</summary>\n\n"
+                 f"{fnd.evidence}\n\n</details>")
+    return body
+
+
+def _area_key(filename):
+    p = filename.split("/")
+    return "/".join(p[:4]) if len(p) >= 4 else (p[0] if p else "misc")
+
+
+def _changes_table(files):
+    areas = {}
+    for f in files:
+        a = areas.setdefault(_area_key(f["filename"]), [0, 0, 0])
+        a[0] += 1
+        a[1] += f.get("additions", 0)
+        a[2] += f.get("deletions", 0)
+    rows = "\n".join(f"| `{k}` | {v[0]} | +{v[1]}/−{v[2]} |"
+                     for k, v in sorted(areas.items(), key=lambda kv: -kv[1][1])[:25])
+    extra = "" if len(areas) <= 25 else f"\n\n_…and {len(areas) - 25} more areas._"
+    return "| Area | Files | Lines |\n|---|--:|--:|\n" + rows + extra
+
+
+def _walkthrough_body(decision, summary, findings, files, overflow, meta):
+    meta = meta or {}
+    verdict = ("✅ **Approve**" if decision == "approve"
+               else "🛑 **Changes requested**")
+    nblock = sum(1 for f in findings if _sev(f) == "blocking") + sum(
+        1 for o in overflow if o[0] == "blocking")
+    nnit = sum(1 for f in findings if _sev(f) == "nit") + sum(1 for o in overflow if o[0] == "nit")
+    bits = [f"blast radius **{meta.get('blast', '?')}**", f"council **{meta.get('council', '?')}**",
+            f"**{meta.get('chunks', '?')}** review areas",
+            f"**{nblock}** blocking · **{nnit}** nits"]
+    head = ("## 🔎 revir feedback\n\n"
+            f"> {verdict}  ·  " + "  ·  ".join(bits) + "\n\n"
+            "<details open>\n<summary>📝 Walkthrough</summary>\n\n" + summary + "\n\n</details>\n\n"
+            "<details>\n<summary>📂 Changes</summary>\n\n" + _changes_table(files) + "\n\n</details>")
+    if overflow:
+        items = "\n".join(o[1] for o in overflow)
+        head += (f"\n\n<details>\n<summary>📌 {len(overflow)} more finding(s) outside the diff</summary>"
+                 f"\n\n{items}\n\n</details>")
+    head += "\n\n<sub>— revir · agentic council review</sub>"
+    return head
+
+
+def post_review(token, owner, repo, num, decision, summary, findings, files, dry_run=False, meta=None):
+    """Post a review: CodeRabbit-style walkthrough body + inline comments for findings
+    on diff lines (the rest folded into a collapsible overflow). decision: 'approve' | 'changes_needed'."""
+    valid = {f["filename"]: valid_comment_lines(f.get("patch", "")) for f in files}
+    inline, overflow = [], []
+    for fnd in findings:
+        path, line = fnd.file, fnd.line
+        if line and path in valid and line in valid[path]:
+            inline.append({"path": path, "line": line, "side": "RIGHT", "body": _finding_body(fnd)})
+        else:
+            tag = "🔴" if _sev(fnd) == "blocking" else "🟡"
+            loc = f"`{path}`" + (f":{line}" if line else "")
+            overflow.append((_sev(fnd), f"- {tag} {loc} — **{fnd.title}**: {fnd.detail}"))
+
+    event = "APPROVE" if decision == "approve" else "COMMENT"
+    head = _walkthrough_body(decision, summary, findings, files, overflow, meta)
+
+    if dry_run:
+        return {"dry_run": True, "event": event, "inline": len(inline), "overflow": len(overflow), "body": head}
+    payload = {"event": event, "body": head}
+    if inline:
+        payload["comments"] = inline
+    try:
+        gh(token, f"/repos/{owner}/{repo}/pulls/{num}/reviews", method="POST", body=payload)
+        return {"event": event, "inline": len(inline), "overflow": len(overflow)}
+    except urllib.error.HTTPError as e:  # noqa: F821
+        detail = e.read().decode("utf-8", "replace")[:300]
+        # self-approval refused, or a bad inline line slipped through -> retry as plain comment
+        payload2 = {"event": "COMMENT", "body": head + (f"\n\n_(inline comments dropped: {detail})_" if detail else "")}
+        gh(token, f"/repos/{owner}/{repo}/pulls/{num}/reviews", method="POST", body=payload2)
+        return {"event": "COMMENT", "inline": 0, "overflow": len(overflow), "fallback": detail}

--- a/maggy/maggy/review/github.py
+++ b/maggy/maggy/review/github.py
@@ -62,6 +62,8 @@ def valid_comment_lines(patch: str) -> set[int]:
             continue
         if newno is None:
             continue
+        if ln.startswith("\\"):
+            continue  # "\ No newline at end of file" — not a real line, don't count it
         if ln.startswith("+"):
             lines.add(newno)
             newno += 1

--- a/maggy/maggy/review/languages.py
+++ b/maggy/maggy/review/languages.py
@@ -1,0 +1,114 @@
+"""Extensible language registry for the council reviewer.
+
+A *language* is: a name, the file extensions (and path markers) that map files
+to it, a skill file (review knowledge injected into the agents), and — for the
+future — an optional static-lint hook. The reviewer is language-agnostic; what
+makes it understand Python vs Go is purely the registry entry + the skill file.
+
+Adding a language needs NO core code change. Either:
+  1. drop ``skills/<name>.md`` and call ``register_language(Language(...))``, or
+  2. declare it in Maggy config under ``review.languages`` (loaded at runtime by
+     ``load_from_config``).
+
+This is the seam the rest of the pipeline detects + loads skills through.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).parent / "skills"
+
+
+@dataclass(frozen=True)
+class Language:
+    """One reviewable language and how to recognize + teach it."""
+
+    name: str
+    extensions: tuple[str, ...] = ()
+    # substrings that, if present in a path, imply this language regardless of
+    # extension (e.g. "/migrations/" -> db even for a .py migration).
+    path_markers: tuple[str, ...] = ()
+    # skill filename under skills/; defaults to "<name>.md".
+    skill_file: str = ""
+
+    def skill_path(self, skills_dir: Path = SKILLS_DIR) -> Path:
+        return skills_dir / (self.skill_file or f"{self.name}.md")
+
+
+# Built-in roster. python/typescript/db carry over from revir; the rest are the
+# seeded "common set" — each is just an entry + a skills/<name>.md file.
+_BUILTINS = (
+    Language("python", (".py",)),
+    Language("typescript", (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs")),
+    Language("db", (".sql",), path_markers=("alembic", "migrations/", "migrations-")),
+    Language("go", (".go",)),
+    Language("rust", (".rs",)),
+    Language("java", (".java",)),
+    Language("csharp", (".cs",)),
+    Language("ruby", (".rb",)),
+    Language("php", (".php",)),
+)
+
+REGISTRY: dict[str, Language] = {lang.name: lang for lang in _BUILTINS}
+
+
+def register_language(lang: Language) -> None:
+    """Add (or replace) a language in the registry."""
+    REGISTRY[lang.name] = lang
+
+
+def supported() -> list[str]:
+    """Names of all registered languages, sorted."""
+    return sorted(REGISTRY)
+
+
+def detect_languages(filenames) -> list[str]:
+    """Languages present in a set of changed file paths (registry-driven)."""
+    found: set[str] = set()
+    for fn in filenames:
+        low = fn.lower()
+        for lang in REGISTRY.values():
+            if any(low.endswith(e) for e in lang.extensions) or any(m in low for m in lang.path_markers):
+                found.add(lang.name)
+    return sorted(found)
+
+
+def load_skill(languages, skills_dir: Path = SKILLS_DIR) -> str:
+    """base skill + the per-language skill for each language the PR touches.
+
+    Unknown language names are skipped silently (their skill file just may not
+    exist yet) — the base skill always loads so a review is never skill-less.
+    """
+    parts: list[str] = []
+    base = skills_dir / "base.md"
+    if base.exists():
+        parts.append(base.read_text())
+    for name in languages:
+        lang = REGISTRY.get(name)
+        path = lang.skill_path(skills_dir) if lang else skills_dir / f"{name}.md"
+        if path.exists():
+            parts.append(path.read_text())
+    return "\n\n".join(parts)
+
+
+def load_from_config(entries) -> list[str]:
+    """Register user-defined languages from Maggy config (``review.languages``).
+
+    Each entry is a dict: ``{name, extensions:[...], path_markers?:[...],
+    skill_file?}``. Returns the names registered. Malformed entries are skipped.
+    """
+    added: list[str] = []
+    for e in entries or []:
+        try:
+            lang = Language(
+                name=e["name"],
+                extensions=tuple(e.get("extensions", ())),
+                path_markers=tuple(e.get("path_markers", ())),
+                skill_file=e.get("skill_file", ""),
+            )
+        except (KeyError, TypeError):
+            continue
+        register_language(lang)
+        added.append(lang.name)
+    return added

--- a/maggy/maggy/review/models.py
+++ b/maggy/maggy/review/models.py
@@ -1,0 +1,75 @@
+"""Typed review schema. A `Finding` maps 1:1 to a GitHub inline review comment."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Severity(str, Enum):
+    blocking = "blocking"   # must fix before merge
+    nit = "nit"             # non-blocking suggestion
+
+
+class Finding(BaseModel):
+    file: str = Field(description="repo-relative path the finding is about")
+    line: int | None = Field(
+        default=None,
+        description="1-based line in the file's NEW version to attach the comment to; null = file-level",
+    )
+    severity: Severity
+    title: str = Field(description="one-line summary of the issue")
+    detail: str = Field(description="explanation and why it matters")
+    suggestion: str | None = Field(default=None, description="concrete fix, if any")
+    evidence: str | None = Field(
+        default=None,
+        description="what tool call / file:line proves this — REQUIRED for a blocking finding so we don't post guesses",
+    )
+
+
+class Verdict(BaseModel):
+    decision: Literal["approve", "changes_needed"]
+    summary: str = Field(description="2-4 sentence overall summary for the PR author")
+    findings: list[Finding] = Field(default_factory=list)
+
+
+class Refutation(BaseModel):
+    """A skeptic's verdict on whether a blocking finding holds up."""
+    refuted: bool = Field(description="true ONLY if you found concrete evidence the finding is FALSE")
+    reason: str = Field(description="why it's refuted (or why it stands)")
+    evidence: str | None = Field(default=None, description="the grep/read result that disproves the claim")
+
+
+class BlastRadius(BaseModel):
+    """Computed during planning — drives how big a council we summon."""
+    impacted_files: list[str] = Field(default_factory=list)
+    impacted_symbols: list[str] = Field(default_factory=list)
+    impacted_endpoints: list[str] = Field(default_factory=list)
+    cross_service: bool = Field(default=False, description="does the change cross a service/bounded-context boundary?")
+    touches_auth_or_data: bool = Field(default=False, description="auth, migrations, money, or PII paths involved?")
+    languages: list[str] = Field(default_factory=list, description="subset of {db, python, typescript}")
+    size: Literal["small", "medium", "large"] = "small"
+    rationale: str = ""
+
+
+class ReviewChunk(BaseModel):
+    name: str
+    focus: str = Field(description="what to scrutinize in this area")
+    files: list[str]
+    languages: list[str] = Field(default_factory=list)
+
+
+class ReviewPlan(BaseModel):
+    """The planner's output: blast radius + a council sized to it."""
+    blast_radius: BlastRadius
+    council_size: int = Field(
+        ge=1, le=6,
+        description="how many reviewer agents to summon, sized to blast radius (small=2, medium=4, large/auth=6)",
+    )
+    rounds: Literal[1, 2] = Field(default=1, description="1 = independent only; 2 = + a discussion round")
+    chunks: list[ReviewChunk] = Field(
+        default_factory=list,
+        description="review areas for a large PR (one panel per chunk); empty = single-pass review",
+    )
+    reason: str = Field(default="", description="why this council size/shape fits the blast radius")

--- a/maggy/maggy/review/pipeline.py
+++ b/maggy/maggy/review/pipeline.py
@@ -1,0 +1,528 @@
+"""Orchestration: plan -> decompose -> review each chunk -> synthesize hierarchically -> post.
+
+Mega-PR strategy (the reason chunking is deterministic, not LLM-decided):
+a huge PR cannot be reviewed — or synthesized — in a single context window. So we
+ALWAYS decompose the changed files into bounded, coherent chunks (by feature area),
+review each chunk with its OWN diff slice (never a truncated global diff), synthesize
+each chunk independently, then merge the per-chunk verdicts deterministically. Every
+LLM call therefore sees a bounded input, no matter how large the PR is.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from pathlib import Path
+
+from pydantic_ai.usage import UsageLimits
+
+from .agents import build_chair, build_planner, build_refuter, build_reviewer
+from .config import CHAIR, PRICING_KEY, available, cost_usd, load_env, load_skill
+from .github import get_pr, get_pr_files, post_review
+from .languages import detect_languages
+from .models import ReviewChunk, Verdict
+from .static_check import run_static_gate
+
+# tool-using review agents make many requests (read_file/grep loops); the default
+# request_limit of 50 is too low for a thorough reviewer/chair.
+LIMITS = UsageLimits(request_limit=150)
+# the planner plans from the embedded file LIST; a tight budget lets it spot-check
+# one or two files without looping read_file calls (which balloon context on a mega PR).
+PLANNER_LIMITS = UsageLimits(request_limit=8)
+# a per-chunk reviewer reviews a bounded slice — 45 tool calls is plenty.
+REVIEWER_LIMITS = UsageLimits(request_limit=45)
+# wall-clock cap per agent — a hung/slow provider must not block a gather.
+AGENT_TIMEOUT = 200
+
+# --- mega-PR decomposition knobs ---------------------------------------------
+SINGLE_PASS_FILES = 8       # <= this many files -> one chunk (the whole PR), full council
+MAX_CHUNK_FILES = 8         # a chunk never reviews more than this many files at once
+MAX_CHUNK_DIFF_CHARS = 20000  # per-chunk diff budget (fits a reviewer context comfortably)
+PER_FILE_DIFF_CHARS = 4000  # per-file patch budget inside a chunk
+PANEL_SIZE_MULTI = 2        # reviewers per chunk when the PR is split into many chunks
+CONCURRENCY = 6             # max in-flight model calls (rate-limit safety on mega PRs)
+REFUTE_CAP = 120            # adversarially verify at most this many blocking findings
+FINDINGS_CAP = 40           # post at most this many findings inline; group the rest
+# finding categories with a high false-positive rate on mega PRs (truncated-diff illusions):
+# refute these FIRST so the cap never leaves one unverified.
+_HIGH_FP = ("i18n", "translation", "german", "locale", "feature flag", "feature-flag",
+            "not gated", "not feature", "unconditional", "missing test", "untranslat", "hardcoded")
+
+# created per-run, inside the event loop (see run_review)
+_SEM: asyncio.Semaphore | None = None
+# model-cost-keys that hit a quota/429 wall this run — skipped for the rest of it
+_DISABLED: set[str] = set()
+
+
+def _is_quota_error(e) -> bool:
+    s = str(e).lower()
+    return any(t in s for t in ("429", "quota", "rate limit", "resource_exhausted", "exceeded"))
+
+
+def _rec(usages, model_key, result):
+    try:
+        u = result.usage()
+        usages.append((model_key, getattr(u, "input_tokens", 0) or 0,
+                       getattr(u, "output_tokens", 0) or 0,
+                       getattr(u, "cache_read_tokens", 0) or 0))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+async def _run_agent(agent, prompt, deps, limits, timeout=AGENT_TIMEOUT):
+    """Run one agent with a wall-clock timeout under the global concurrency cap."""
+    async def _go():
+        return await asyncio.wait_for(agent.run(prompt, deps=deps, usage_limits=limits), timeout=timeout)
+    if _SEM is not None:
+        async with _SEM:
+            return await _go()
+    return await _go()
+
+
+# Optional map of "owner/repo" -> local checkout path, for the static gate +
+# deterministic FP filter. Maggy passes repo_path explicitly per request; this
+# can be populated from config (review.repo_paths) for convenience.
+REPO_PATHS: dict[str, Path] = {}
+
+
+def _area_key(filename: str) -> str:
+    """Coherent review-area key for a path: the feature/folder it belongs to."""
+    p = filename.split("/")
+    return "/".join(p[:4]) if len(p) >= 4 else (p[0] if p else "misc")
+
+
+def decompose(files, langs) -> list[ReviewChunk]:
+    """Deterministically split the PR into bounded, coherent review chunks.
+
+    Small PRs become a single chunk (whole PR). Larger PRs are grouped by feature
+    area and each oversized group is sliced to <= MAX_CHUNK_FILES. This guarantees
+    the whole PR is covered and every chunk fits one reviewer context — regardless
+    of how the planner LLM behaves on a huge file list.
+    """
+    names = [f["filename"] for f in files]
+    if len(names) <= SINGLE_PASS_FILES:
+        return [ReviewChunk(name="whole PR", focus="the entire change", files=names, languages=langs)]
+    groups: dict[str, list[str]] = {}
+    for fn in names:
+        groups.setdefault(_area_key(fn), []).append(fn)
+    chunks: list[ReviewChunk] = []
+    for key, g in sorted(groups.items()):
+        for j in range(0, len(g), MAX_CHUNK_FILES):
+            sub = g[j:j + MAX_CHUNK_FILES]
+            suffix = f" [{j // MAX_CHUNK_FILES + 1}]" if len(g) > MAX_CHUNK_FILES else ""
+            clangs = detect_languages(sub) or langs
+            chunks.append(ReviewChunk(name=key + suffix, focus="this area of the change",
+                                      files=sub, languages=clangs))
+    return chunks
+
+
+def chunk_diff_text(files, chunk_files, per_file=PER_FILE_DIFF_CHARS, cap=MAX_CHUNK_DIFF_CHARS):
+    """Diff text for ONLY this chunk's files — so a reviewer never judges on a
+    truncated global diff (the bug that produced false positives on mega PRs)."""
+    want = set(chunk_files)
+    parts = []
+    for f in files:
+        if f["filename"] in want and f.get("patch"):
+            parts.append(f"--- {f['filename']} (+{f.get('additions', 0)}/-{f.get('deletions', 0)}) ---\n"
+                         f"{f['patch'][:per_file]}")
+    return "\n\n".join(parts)[:cap]
+
+
+def fallback_plan(files, langs):
+    """Heuristic ReviewPlan when the planner LLM fails — risk only; decompose() owns chunking."""
+    from .models import BlastRadius, ReviewPlan
+    return ReviewPlan(
+        blast_radius=BlastRadius(languages=langs, size="large", touches_auth_or_data=True,
+                                 rationale="planner unavailable — heuristic risk assessment"),
+        council_size=5, rounds=1, chunks=[],
+        reason="heuristic fallback (planner failed/over-budget)")
+
+
+async def review_one(name, factory, skill, focus, title, deps, on_log, usages, model_key,
+                     with_tools=True, diff_text=""):
+    if model_key in _DISABLED:  # this model already hit its quota wall this run
+        return None
+    rv = build_reviewer(factory(), skill, focus, with_tools=with_tools)
+    prompt = (
+        f"Review this PR: {title}. "
+        + ("Use your tools (read_file/grep/get_diff) to VERIFY before flagging. "
+           if with_tools else "Review the diff below; cite file:line. ")
+        + ("Focus: " + focus if focus else "Review the whole change.")
+    )
+    if diff_text:
+        prompt += f"\n\n--- DIFF (this review area) ---\n{diff_text}"
+    try:
+        res = await _run_agent(rv, prompt, deps, REVIEWER_LIMITS)
+        _rec(usages, model_key, res)
+        return res.output
+    except Exception as e:  # noqa: BLE001 (TimeoutError included)
+        if _is_quota_error(e):
+            _DISABLED.add(model_key)
+            on_log(f"[review] {model_key} hit quota/429 — disabling it for the rest of this run")
+        else:
+            on_log(f"[review] {name} FAILED: {type(e).__name__}: {str(e)[:160]}")
+        return None
+
+
+def _dedup_findings(verdicts):
+    """Union findings across verdicts, deduped by (file, line, ~title). Preserves order + full detail."""
+    seen, order = {}, []
+    for v in verdicts:
+        for fd in v.findings:
+            k = (fd.file, fd.line, fd.title.strip().lower()[:60])
+            if k not in seen:
+                seen[k] = fd
+                order.append(k)
+    return [seen[k] for k in order]
+
+
+def _deterministic_verdict(verdicts, note=""):
+    merged = _dedup_findings(verdicts)
+    blocked = any(fd.severity.value == "blocking" for fd in merged) or \
+        any(v.decision == "changes_needed" for v in verdicts)
+    summary = (note + " | ".join(v.summary[:140] for v in verdicts[:3])) if verdicts else (note or "no findings")
+    return Verdict(decision="changes_needed" if blocked else "approve", summary=summary, findings=merged)
+
+
+# --- deterministic false-positive filter (no LLM) -----------------------------
+# The two FP classes that dominate mega-PR reviews are MECHANICALLY checkable, so we
+# verify them in code instead of relying on a per-finding LLM (which is inconsistent):
+#   1. "missing translation key" — grep the real locale JSON; if every key the file
+#      uses resolves in BOTH en and de, the claim is false.
+#   2. "not feature-flagged" on a sub-component — flag gating is an ENTRY-POINT concern;
+#      a component that isn't a routed entry point doesn't get its own flag.
+_RE_KEY = re.compile(r"""t\(\s*['"]([a-zA-Z0-9_.]+)['"]""")
+_RE_I18N = re.compile(r"(i18n|translation|locale|missing.{0,15}key|de (locale|translation)|"
+                      r"informal|not localized|missing 'de'|missing de)", re.I)
+_RE_FLAG = re.compile(r"(feature.?flag|not gated|feature-flag|unconditional|not feature)", re.I)
+
+
+def _flat_keys(path):
+    keys = set()
+    try:
+        data = json.loads(Path(path).read_text())
+    except Exception:  # noqa: BLE001
+        return keys
+
+    def walk(o, p=""):
+        for k, v in o.items():
+            walk(v, p + k + ".") if isinstance(v, dict) else keys.add(p + k)
+    walk(data)
+    return keys
+
+
+def _resolves(key, ks):
+    return key in ks or any(key + s in ks for s in ("_one", "_other", "_plural", "_zero", "_many"))
+
+
+def _git_show(lp, ref, path):
+    try:
+        import subprocess
+        r = subprocess.run(["git", "-C", str(lp), "show", f"{ref}:{path}"],
+                           capture_output=True, text=True, timeout=15)
+        return r.stdout if r.returncode == 0 else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _routed(comp, router_text):
+    # a component is a routed entry point if its name appears as a word in the router
+    return bool(comp) and re.search(rf"\b{re.escape(comp)}\b", router_text) is not None
+
+
+def _gated(comp, router_text):
+    # is the component's mount inside a feature-flag conditional? (e.g. {zennyEnabled && <X/>})
+    for m in re.finditer(rf"\b{re.escape(comp)}\b", router_text):
+        ctx = router_text[max(0, m.start() - 400):m.start()]
+        if re.search(r"Enabled\s*&&|useFeatureFlag|can_use_\w+\s*&&|FF_\w+\s*&&", ctx):
+            return True
+    return False
+
+
+def deterministic_fp_filter(findings, local_path, on_log, base_ref=None):
+    if not local_path:
+        return findings, 0
+    lp = Path(local_path)
+    en = _flat_keys(lp / "libs/shared/services/translate/src/lib/locals/en/en.json")
+    de = _flat_keys(lp / "libs/shared/services/translate/src/lib/locals/de/de.json")
+    rp = lp / "apps/zenloop-app/src/Router.tsx"
+    router = rp.read_text(errors="replace") if rp.exists() else ""
+    # the same router on the BASE branch — to tell a NEW ungated route from a
+    # pre-existing one (a finding "not feature-flagged" is only real for a NEW entry point).
+    base_router = _git_show(lp, f"origin/{base_ref}", "apps/zenloop-app/src/Router.tsx") if base_ref else ""
+    kept, dropped = [], 0
+    for f in findings:
+        if getattr(f.severity, "value", f.severity) != "blocking":
+            kept.append(f)
+            continue
+        blob = f"{f.title} {f.detail}".lower()
+        fpath = lp / f.file
+        # (1) missing-translation-key FP: every zenny.* key the file uses resolves in both locales
+        if en and de and _RE_I18N.search(blob) and "hardcod" not in blob and fpath.exists():
+            used = {k for k in _RE_KEY.findall(fpath.read_text(errors="replace")) if k.startswith("zenny.")}
+            if used and all(_resolves(k, en) and _resolves(k, de) for k in used):
+                dropped += 1
+                on_log(f"[det-fp] i18n FP dropped: {f.title[:55]} ({len(used)} keys all resolve en+de)")
+                continue
+        # (2) not-feature-flagged FP. Flag gating is an ENTRY-POINT concern, so the
+        # finding is false unless this PR introduces a NEW ungated route:
+        #   - component isn't routed at all  -> sub-component, inherits its host's gate
+        #   - component is routed on the BASE branch too -> pre-existing, not new
+        if router and _RE_FLAG.search(blob):
+            comp = Path(f.file).stem
+            if not _routed(comp, router):
+                dropped += 1
+                on_log(f"[det-fp] flag FP dropped: {f.title[:55]} ({comp} is a sub-component, not a route)")
+                continue
+            if base_router and _routed(comp, base_router):
+                dropped += 1
+                on_log(f"[det-fp] flag FP dropped: {f.title[:55]} ({comp} route pre-exists on base)")
+                continue
+            if _gated(comp, router):
+                dropped += 1
+                on_log(f"[det-fp] flag FP dropped: {f.title[:55]} ({comp} is already behind a feature flag)")
+                continue
+        kept.append(f)
+    return kept, dropped
+
+
+async def process_chunk(idx, chunk, council, skill, title, deps, on_log, usages, panel_size):
+    """Review one chunk with a rotating panel on its OWN diff, then merge its panel.
+
+    Per-chunk synthesis is DETERMINISTIC (dedup the panel's findings) — an LLM chair
+    per chunk was redundant with the adversarial refute pass and was the dominant
+    cost on a mega PR. The refute pass (later) is what verifies/kills false blockers."""
+    panel = (council[idx % len(council):] + council[: idx % len(council)])[: min(panel_size, len(council))]
+    cdiff = chunk_diff_text(deps.files, chunk.files)
+    focus = (f"Area '{chunk.name}': {chunk.focus}. Files: {', '.join(chunk.files[:25])}. "
+             "Only flag issues in THESE files; the diff for them is below.")
+    revs = await asyncio.gather(*[
+        review_one(f"{n}@{chunk.name}", f, skill, focus, title, deps, on_log, usages,
+                   PRICING_KEY.get(n, ""), tools, cdiff)
+        for (n, f, _l, tools) in panel])
+    verdicts = [v for v in revs if v]
+    if not verdicts:
+        on_log(f"[chunk] {chunk.name}: no reviewer verdicts")
+        return None
+    cv = _deterministic_verdict(verdicts)
+    nblock = sum(1 for fd in cv.findings if fd.severity.value == "blocking")
+    on_log(f"[chunk] {chunk.name}: {len(verdicts)} reviews -> {len(cv.findings)} findings ({nblock} blocking)")
+    return cv
+
+
+async def final_summary(chunk_verdicts, skill, chair_factory, chair_key, deps, usages, on_log):
+    """A short overall summary across chunks. Findings are merged deterministically
+    (not regenerated), so this call stays tiny even with dozens of chunks."""
+    text = "\n\n".join(f"### area {i + 1} ({v.decision})\n{v.summary}"
+                       for i, v in enumerate(chunk_verdicts))[:8000]
+    chair = build_chair(chair_factory(), skill, with_tools=False)  # prose only — no file reads
+    try:
+        res = await _run_agent(
+            chair, "Write ONE 2-4 sentence overall verdict summary for the PR author from these "
+            "per-area summaries. Do not list findings; they are aggregated separately.\n\n" + text,
+            deps, PLANNER_LIMITS, timeout=AGENT_TIMEOUT)
+        _rec(usages, chair_key, res)
+        return res.output.summary
+    except Exception:  # noqa: BLE001
+        return " | ".join(v.summary[:120] for v in chunk_verdicts[:4])
+
+
+async def run_review(owner, repo, num, dry_run=True, repo_path=None, on_log=print, token=None):
+    global _SEM
+    load_env()
+    from .tools import ReviewDeps  # imported here so config.load_env() ran first
+
+    _SEM = asyncio.Semaphore(CONCURRENCY)
+    _DISABLED.clear()
+    token = token or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("no GitHub token — set review.github_token, pass an override, or export GITHUB_TOKEN")
+    pr = get_pr(token, owner, repo, num)
+    files = get_pr_files(token, owner, repo, num)
+    head = pr["head"]["sha"]
+    langs = detect_languages([f["filename"] for f in files])
+    lp = Path(repo_path) if repo_path else REPO_PATHS.get(f"{owner}/{repo}")
+    deps = ReviewDeps(token, owner, repo, head, files, local_path=lp if lp and Path(lp).exists() else None)
+
+    # DETERMINISTIC STATIC GATE — runs the real compiler/linter concurrently with the
+    # council (the council reads diffs but never compiles, so it misses undefined refs,
+    # type errors, syntax errors). Its findings are ground truth -> skip refute.
+    static_task = asyncio.create_task(run_static_gate(deps, langs, on_log))
+
+    roster = available()
+    if not roster:
+        raise SystemExit("no model providers available (set keys in revir/.env)")
+    by_name = {n: f for n, f, _lbl, _t in roster}
+    chair_name = CHAIR if CHAIR in by_name else roster[0][0]
+    chair_factory = by_name[chair_name]
+    chair_key = PRICING_KEY.get(chair_name, "")
+    on_log(f"[plan] {len(files)} files, languages={langs}, roster={[n for n, _, _, _ in roster]}")
+
+    usages = []  # (model_key, in, out, cached) per agent run — for cost
+
+    # 1) PLAN — blast radius + council size (decompose() owns the actual chunking)
+    file_list = "\n".join(f"  {f['filename']} (+{f.get('additions', 0)}/-{f.get('deletions', 0)})"
+                          for f in files)[:9000]
+    planner = build_planner(chair_factory(), with_tools=False)  # plan from the file list; no read loops
+    try:
+        pres = await _run_agent(planner,
+            f"Plan the review for PR #{num}: {pr.get('title')} "
+            f"(+{pr.get('additions')}/-{pr.get('deletions')}, {pr.get('changed_files')} files). "
+            f"Languages: {langs}.\n\nCHANGED FILES:\n{file_list}\n\n"
+            "Assess blast radius + council size from this file list alone. "
+            "(Chunking is handled deterministically — leave chunks empty.)",
+            deps, PLANNER_LIMITS)
+        _rec(usages, chair_key, pres)
+        plan = pres.output
+    except Exception as e:  # noqa: BLE001 — never crash the run on a planner failure
+        on_log(f"[plan] planner failed ({type(e).__name__}: {str(e)[:80]}); using heuristic plan")
+        plan = fallback_plan(files, langs)
+    skill = load_skill(plan.blast_radius.languages or langs)
+
+    # 2) DECOMPOSE — deterministic, always (the mega-PR backbone)
+    chunks = decompose(files, langs)
+    # Reviewers PROPOSE, the chair/refuter DISPOSE: keep the (premium) chair model out
+    # of the bulk reviewer council so it isn't double-billed doing tool-heavy chunk
+    # reviews — on a mega PR that one change is the difference between ~$2.4 and ~$1.
+    reviewers = [r for r in roster if r[0] != chair_name] or roster
+    council = reviewers[: max(1, min(plan.council_size, len(reviewers)))]
+    panel_size = len(council) if len(chunks) == 1 else min(PANEL_SIZE_MULTI, len(council))
+    title = pr.get("title", "")
+    on_log(f"[plan] blast={plan.blast_radius.size} council={len(council)} chunks={len(chunks)} "
+           f"panel/chunk={panel_size} — {plan.reason[:70]}")
+
+    # 3) REVIEW + deterministic per-chunk merge, all chunks concurrently (bounded by _SEM)
+    chunk_results = await asyncio.gather(*[
+        process_chunk(i, ch, council, skill, title, deps, on_log, usages, panel_size)
+        for i, ch in enumerate(chunks)])
+    chunk_verdicts = [cv for cv in chunk_results if cv]
+    on_log(f"[review] {len(chunk_verdicts)}/{len(chunks)} chunks produced a verdict")
+
+    # 4) MERGE chunks -> one final verdict. Findings are deduped deterministically;
+    #    only the short prose summary is LLM-written, so this step never overflows.
+    if not chunk_verdicts:
+        final = Verdict(decision="changes_needed",
+                        summary="Review could not be completed — no chunk produced a verdict.", findings=[])
+    else:
+        merged = _dedup_findings(chunk_verdicts)
+        blocked = any(fd.severity.value == "blocking" for fd in merged)
+        summ = await final_summary(chunk_verdicts, skill, chair_factory, chair_key, deps, usages, on_log)
+        final = Verdict(decision="changes_needed" if blocked else "approve",
+                        summary=summ, findings=merged)
+
+    # 4b) DETERMINISTIC FP FILTER — kill mechanically-checkable false positives (no LLM)
+    base_ref = (pr.get("base") or {}).get("ref")
+    final.findings, det_dropped = deterministic_fp_filter(final.findings, deps.local_path, on_log, base_ref)
+    if det_dropped:
+        on_log(f"[det-fp] dropped {det_dropped} mechanically-verified false positive(s)")
+        if not any(f.severity.value == "blocking" for f in final.findings):
+            final.decision = "approve"
+
+    # 5) REFUTE — adversarially verify every remaining blocking finding (kills the rest)
+    blocking = [f for f in final.findings if f.severity.value == "blocking"]
+    refuter_factory = by_name.get("Hopper") or chair_factory  # strong, tool-capable
+    refuter_key = PRICING_KEY.get("Hopper", chair_key) if "Hopper" in by_name else chair_key
+
+    async def refute(fd):
+        r = build_refuter(refuter_factory())
+        claim = (f"DISPROVE this BLOCKING finding if you can:\nTitle: {fd.title}\n"
+                 f"Location: {fd.file}:{fd.line or '-'}\nDetail: {fd.detail}\n"
+                 f"Reviewer's evidence: {fd.evidence}")
+        try:
+            out = await _run_agent(r, claim, deps, LIMITS)
+            _rec(usages, refuter_key, out)
+            return fd, out.output
+        except Exception:  # noqa: BLE001 — on refuter error, keep the finding (fail safe)
+            return fd, None
+
+    if blocking:
+        # Refute high-false-positive categories FIRST (truncated-diff illusions like
+        # "missing translation" / "not feature-flagged"), so the cap never leaves one
+        # of those unverified. Remainder is kept (fail-safe: unverified blockers stay).
+        def _fp_first(fd):
+            blob = f"{fd.title} {fd.detail}".lower()
+            return 0 if any(t in blob for t in _HIGH_FP) else 1
+        blocking.sort(key=_fp_first)
+        to_refute, unrefuted = blocking[:REFUTE_CAP], blocking[REFUTE_CAP:]
+        survived, dropped = [], 0
+        for fd, ref in await asyncio.gather(*[refute(f) for f in to_refute]):
+            if ref and ref.refuted:
+                dropped += 1
+                on_log(f"[refute] DROPPED false positive: {fd.title[:60]} — {ref.reason[:90]}")
+            else:
+                survived.append(fd)
+        survived += unrefuted
+        nits = [f for f in final.findings if f.severity.value == "nit"]
+        final.findings = survived + nits
+        notes = []
+        if dropped:
+            notes.append(f"{dropped} flagged blocker(s) dropped after adversarial verification")
+        if unrefuted:
+            notes.append(f"{len(unrefuted)} blocker(s) kept un-individually-verified (refute cap {REFUTE_CAP})")
+        if notes:
+            final.summary = f"_({'; '.join(notes)}.)_ " + final.summary
+        if not survived:
+            final.decision = "approve"
+        on_log(f"[refute] {len(survived)}/{len(blocking)} blocking findings survived "
+               f"({len(to_refute)} refuted, {len(unrefuted)} over cap)")
+
+    # STATIC GATE — merge deterministic compiler/linter errors. Ground truth, so they
+    # bypass the FP filter AND the refute pass, and they force changes_needed.
+    try:
+        static_findings = await static_task
+    except Exception as e:  # noqa: BLE001
+        on_log(f"[static] gate errored ({type(e).__name__}); continuing without it")
+        static_findings = []
+    if static_findings:
+        final.findings = static_findings + final.findings
+        final.decision = "changes_needed"
+        final.summary = (f"_({len(static_findings)} deterministic build/type error(s) caught by the "
+                         "static gate — these break the build and must be fixed.)_ " + final.summary)
+
+    # When findings are overwhelming (pervasive debt on a mega PR), cap what we post
+    # inline and fold the rest into a grouped, per-file summary so the output stays
+    # actionable instead of being hundreds of comments.
+    if len(final.findings) > FINDINGS_CAP:
+        def _rank(f):  # static (ground-truth) first, then blocking, then nits
+            if f.evidence and "static analysis" in f.evidence:
+                return 0
+            return 1 if f.severity.value == "blocking" else 2
+        kept = sorted(final.findings, key=_rank)[:FINDINGS_CAP]
+        overflow = [f for f in final.findings if f not in kept]
+        by_file: dict[str, int] = {}
+        for f in overflow:
+            by_file[f.file] = by_file.get(f.file, 0) + 1
+        top = sorted(by_file.items(), key=lambda kv: -kv[1])[:12]
+        grouped = "; ".join(f"{fp} ({n})" for fp, n in top)
+        final.summary += (f"\n\n**+{len(overflow)} more findings across {len(by_file)} files** "
+                          f"(showing {FINDINGS_CAP} inline). Most-affected: {grouped}.")
+        final.findings = kept
+        on_log(f"[cap] posting {len(kept)} findings inline; grouped {len(overflow)} into summary")
+
+    # cost accounting (cache_read discounted — see config.cost_usd)
+    by_model, total_in, total_out, total_cached, total_cost = {}, 0, 0, 0, 0.0
+    for k, i, o, cr in usages:
+        c = cost_usd(k, i, o, cr)
+        m = by_model.setdefault(k or "?", [0, 0, 0, 0.0])
+        m[0] += i
+        m[1] += o
+        m[2] += cr
+        m[3] += c
+        total_in += i
+        total_out += o
+        total_cached += cr
+        total_cost += c
+    on_log(f"[cost] ~${total_cost:.3f}  ({total_in / 1000:.0f}k in ({total_cached / 1000:.0f}k cached) "
+           f"+ {total_out / 1000:.0f}k out over {len(usages)} model runs)")
+    cost = {"total_usd": round(total_cost, 4), "input_tokens": total_in, "output_tokens": total_out,
+            "cached_tokens": total_cached, "runs": len(usages),
+            "by_model": {k: {"in": v[0], "out": v[1], "cached": v[2], "usd": round(v[3], 4)}
+                         for k, v in by_model.items()}}
+
+    # 6) POST
+    meta = {"blast": plan.blast_radius.size, "council": len(council), "chunks": len(chunks)}
+    result = post_review(token, owner, repo, num, final.decision, final.summary, final.findings,
+                         files, dry_run=dry_run, meta=meta)
+    return {"plan": plan, "chunks": chunks, "verdicts": chunk_verdicts,
+            "final": final, "post": result, "cost": cost}

--- a/maggy/maggy/review/skills/base.md
+++ b/maggy/maggy/review/skills/base.md
@@ -1,0 +1,30 @@
+# Review skill — base (always loaded)
+
+You are a senior reviewer on the **zenloop** platform reviewing a GitHub PR.
+Language-specific skills are appended below this one. You have TOOLS — USE THEM:
+do not guess about code you can read. Before claiming a symbol is undefined,
+a test is incomplete, or a file is truncated, call `read_file`/`grep` and verify.
+Every **blocking** finding MUST cite concrete `evidence` (a `file:line` you read
+or a tool result). Uncited blocking findings will be dropped.
+
+## Platform
+- **surveys-backend** (`zensurveys`): V2 survey/CX backend — FastAPI · Python 3.12
+  async · SQLAlchemy 2 + psycopg3 · Auth0 · Alembic. Layered:
+  routes→services→repositories. Integration branch `staging-v2`.
+- **zenEmail**: the platform's **email service** (Python). Downstream of
+  surveys-backend's `send-transactional` calls (`X-Internal-Token`, ADR-0029).
+  Predates the V2 layering ADRs — judge on general best practices, not V2 layering.
+- **frontend-app** (`main-frontend-clean`): Nx/React monorepo. Integration `development`.
+- **zenloop-db**: canonical Alembic migrations (append-only; applied on merge to `main`).
+
+ADRs live in `<repo>/docs/ADRs/NNNN-*.md` (and a platform-wide set). They are
+append-only with a Status; a PR must not contradict an **Accepted** ADR — use
+`read_adr` / `grep` to check before flagging or clearing an ADR concern.
+
+## Output
+Return a typed `Verdict`: `decision` (approve | changes_needed), a short
+`summary`, and `findings`. Each finding has `file`, `line` (1-based in the NEW
+file, for an inline comment), `severity` (blocking | nit), `title`, `detail`,
+optional `suggestion`, and `evidence`. Approve only if you would merge as-is.
+A PR-review judges whether **THIS diff** introduces a problem — pre-existing debt
+in unchanged code is a nit/follow-up, not a blocker.

--- a/maggy/maggy/review/skills/csharp.md
+++ b/maggy/maggy/review/skills/csharp.md
@@ -1,0 +1,25 @@
+# Review skill — C# / .NET
+
+## Anti-patterns — flag on sight
+- `async void` (except event handlers) → `async Task`; exceptions are otherwise unobservable (BLOCKING).
+- `.Result` / `.Wait()` / `.GetAwaiter().GetResult()` on async in a request path → deadlock/thread-starvation (BLOCKING).
+- Missing `await` (fire-and-forget Task) where completion/errors matter.
+- `IDisposable` not disposed — no `using` / `await using` (leak, BLOCKING).
+- String-built SQL → parameterized commands / EF parameters (SQL injection, BLOCKING/security).
+- Swallowed exceptions `catch {}`; catching `Exception` then continuing silently.
+- `DateTime.Now` for timestamps/storage → `DateTime.UtcNow`/`DateTimeOffset`.
+
+## Correctness & async
+- `CancellationToken` threaded through async APIs and honored.
+- `ConfigureAwait(false)` in library code; no `.Result` reentrancy.
+- Nullable reference types respected — no `!` null-forgiving to silence a real null.
+- LINQ that enumerates a query multiple times or hides N+1 DB round-trips.
+- `==` vs `.Equals` for value semantics; struct mutation copies.
+
+## Idioms
+- Dependency injection via constructor; `IOptions<T>` for config, not static reads.
+- `record`/immutability for DTOs; expression-bodied where it reads clearer.
+
+## Tests
+- xUnit/NUnit tests for new behavior incl. async exception + cancellation paths.
+- Cover the failure branches; don't assert only on mock interactions.

--- a/maggy/maggy/review/skills/db.md
+++ b/maggy/maggy/review/skills/db.md
@@ -1,0 +1,32 @@
+# Review skill — DB / migrations (zenloop-db, Alembic / SQL)
+
+Migrations are **append-only** and high-blast-radius — scrutinize hard.
+
+## Blocking
+- **Destructive ops** — `DROP TABLE`, `DROP COLUMN`, `ALTER COLUMN ... TYPE`,
+  `TRUNCATE` — without an explicit ADR justifying them. Default-block; require a
+  linked Accepted ADR (read it) before clearing.
+- **`ADD COLUMN ... NOT NULL` without a `DEFAULT`/backfill** on a non-empty table
+  → write failure / long lock. Require a default or a staged backfill.
+- **One service's migration touching another's schema** (must be per-service:
+  `surveys.*`, `email.*`, `ai.*`, `shared.*`).
+- **Non-parameterized dynamic SQL** built from input.
+
+## Scrutinize (flag with rationale)
+- **`ON DELETE` action** on new FKs: is `CASCADE` vs `RESTRICT`/`SET NULL`
+  justified? `CASCADE` on a parent can wipe large child trees (and cascade
+  transitively — check the child's own FK delete action with `grep`). `SET NULL`
+  needs the column nullable. The choice must be reasoned in the ADR.
+- **`NOT VALID` FK pattern**: adding `NOT VALID` then deferring `VALIDATE` is the
+  correct low-lock pattern when pre-existing rows would fail — confirm the ADR
+  explains why VALIDATE is deferred.
+- **Reversibility**: does `downgrade` exist and undo cleanly?
+- **Index creation** on large tables should be `CONCURRENTLY` (outside a txn).
+- **Migration numbering**: unique, sequential; no collision with an existing
+  migration or **ADR** number (grep the registry — ADR/migration numbers are
+  separate namespaces but both must be unique within their own).
+
+## Verify
+- Use `grep`/`read_file` against `zenloop-db` and the schema docs to confirm FK
+  delete actions, existing migration numbers, and whether a referenced table/column
+  actually exists — don't assert from the diff alone.

--- a/maggy/maggy/review/skills/go.md
+++ b/maggy/maggy/review/skills/go.md
@@ -1,0 +1,26 @@
+# Review skill — Go
+
+## Anti-patterns — flag on sight
+- Ignored errors: `val, _ := f()` where the error matters, or a bare `f()` that returns an error (BLOCKING).
+- `err` checked but the underlying value used anyway after a non-nil error.
+- Goroutine leaks: a goroutine with no exit path / unbuffered channel send with no receiver.
+- `context.Context` not threaded through to blocking/IO calls; `context.Background()` deep in a call chain.
+- Mutating a map/slice shared across goroutines without a mutex or channel (data race) (BLOCKING).
+- `defer` inside a loop accumulating until function return (resource exhaustion).
+- Naked `panic` in library code where an error return is expected.
+
+## Correctness & concurrency
+- `sync.WaitGroup` Add/Done balance; `Wait` actually reached on all paths.
+- Channel close ownership (only the sender closes); no send on a closed channel.
+- Slice aliasing: `append` reusing backing arrays causing surprise mutation.
+- `nil` map writes (panic); `nil` interface vs typed-nil comparison bugs.
+- Error wrapping with `%w` so callers can `errors.Is/As`; don't lose the chain.
+
+## Idioms
+- Return early; keep the happy path un-indented.
+- Accept interfaces, return structs. Small interfaces at the consumer.
+- No unused exported surface; lowercase what isn't part of the API.
+
+## Tests
+- Table-driven tests for new behavior; cover the error branches, not just happy path.
+- `t.Parallel()` only where state is independent; race detector clean (`go test -race`).

--- a/maggy/maggy/review/skills/java.md
+++ b/maggy/maggy/review/skills/java.md
@@ -1,0 +1,25 @@
+# Review skill — Java
+
+## Anti-patterns — flag on sight
+- Swallowed exceptions: `catch (Exception e) {}` or catch-and-`printStackTrace` then continue (BLOCKING).
+- Resources not closed: streams/connections/statements opened without try-with-resources (leak, BLOCKING).
+- String concatenation building SQL → `PreparedStatement` with bind params (SQL injection, BLOCKING/security).
+- `==` on objects (Strings, boxed numbers) where `.equals()` is meant.
+- Returning `null` for a collection → return empty collection; `Optional` for maybe-absent scalars.
+- Mutable static state / non-thread-safe singletons shared across threads.
+- Catching `Throwable`/`Error`; swallowing `InterruptedException` without restoring the interrupt.
+
+## Correctness & concurrency
+- `equals`/`hashCode` overridden together and consistent; used as map keys safely.
+- Unsynchronized access to shared mutable fields; check-then-act races → atomics/locks.
+- Integer overflow / division; autoboxing NPEs (`Integer` unboxed when null).
+- Stream pipelines with side effects or that consume a stream twice.
+- Time/locale: `Instant`/`ZonedDateTime` over legacy `Date`; explicit `ZoneId`.
+
+## Idioms
+- Constructor injection over field injection; immutable objects/`final` where possible.
+- Narrow visibility; no leaking internal mutable collections (defensive copies).
+
+## Tests
+- JUnit tests for new behavior incl. exception paths; no logic only covered by mocks.
+- Assert on behavior/return, not implementation calls, where feasible.

--- a/maggy/maggy/review/skills/php.md
+++ b/maggy/maggy/review/skills/php.md
@@ -1,0 +1,25 @@
+# Review skill — PHP / Laravel
+
+## Anti-patterns — flag on sight
+- Raw query with interpolated input → prepared statements / query-builder bindings (SQL injection, BLOCKING/security).
+- Unescaped output in templates → `echo` of user data without `htmlspecialchars`/Blade `{{ }}` (XSS, BLOCKING).
+- Mass assignment without `$fillable`/`$guarded`; `Model::create($request->all())` (BLOCKING).
+- `@` error suppression; `catch (\Exception $e) {}` swallow; continuing after a failed operation.
+- `==` loose comparison on auth/identity values → `===` (type-juggling auth bypass, BLOCKING/security).
+- N+1: Eloquent relation accessed in a loop without eager `with()`.
+- Secrets in code / committed `.env`; `env()` called outside config (cached config breaks it).
+
+## Correctness
+- Null/undefined array keys (`$a['k']` without `isset`/`??`); nullable returns handled.
+- Money as float (BLOCKING) → integer minor units / a money library.
+- Authorization (policies/gates) enforced per action, scoped to the current user/tenant.
+- Validation at the boundary (Form Requests), not ad-hoc in controllers.
+- Mixing business logic into controllers/models → services/actions.
+
+## Idioms
+- `declare(strict_types=1)`; typed properties + return types.
+- Dependency injection via the container, not `new`/facades deep in logic.
+
+## Tests
+- PHPUnit/Pest tests for new behavior incl. validation + authorization failure paths.
+- Don't cover new code only via HTTP mocks; assert real outcomes.

--- a/maggy/maggy/review/skills/python.md
+++ b/maggy/maggy/review/skills/python.md
@@ -1,0 +1,38 @@
+# Review skill — Python (surveys-backend / zenEmail)
+
+## Hard rules (a violation in surveys-backend = BLOCKING)
+1. Routes never touch the DB — they call services.
+2. Services never run raw SQL / import the DB driver — they call repositories.
+3. Repositories are the only DB layer; one repo owns one schema.
+4. No cross-service repository imports — cross-context reads go via HTTP (gateway)
+   or a domain event, never `from other_service... import`.
+5. Pydantic schemas at the HTTP boundary; internal types are dataclasses/domain models.
+6. Per-service Alembic migrations — a migration only touches its own schema.
+7. Auth0 JWT for end-users at the gateway; PASETO between services. Never share user tokens.
+
+(zenEmail predates these — there, apply general best practices, not the layering rule.)
+
+## Anti-patterns — flag on sight
+- `datetime.utcnow()` / naive `datetime.now()` → `datetime.now(timezone.utc)` (BLOCKING).
+- Pydantic v1: `.dict()`, `@validator`, `class Config:` → v2 `.model_dump()`,
+  `@field_validator`, `model_config` (BLOCKING — CI greps for these).
+- `os.getenv()` / `os.environ.get()` in `app/` → typed field on `Settings` (BLOCKING).
+- `supabase.table(...)` / `from supabase` in a service (ADR-0006 removed it) (BLOCKING).
+- `psycopg2` (ADR-0005 = psycopg3 only) (BLOCKING).
+- `try/except Exception: pass` swallow → propagate or log + re-raise specific types.
+- `print()` for logging → `logger.info("...: %s", v)`.
+- Raw SQL string-built (SQL injection) → parameterized only (BLOCKING/security).
+- Secrets/PII in logs (mask to last 4); secrets in code → `Settings` + env.
+
+## Correctness & async
+- Un-awaited coroutines, blocking calls in async paths, sync DB in async handlers.
+- None/empty handling; treating a `datetime` as a `str` (e.g. `created_at[:10]`).
+- `org_id` scoping on every authenticated route/query (authz is app-level, R-063).
+
+## Tests (verify, don't assume)
+- New behavior needs tests that exercise the change (not mock-only).
+- Async tests: confirm `asyncio_mode = auto` in `pytest.ini`/`pyproject.toml`
+  (read it) before claiming bare `async def` tests are no-ops.
+- Cover failure paths and `org_id` boundaries; flag untested new code paths.
+
+## Migrations touched from Python → also load the **db** skill rules.

--- a/maggy/maggy/review/skills/ruby.md
+++ b/maggy/maggy/review/skills/ruby.md
@@ -1,0 +1,24 @@
+# Review skill — Ruby / Rails
+
+## Anti-patterns — flag on sight
+- String-interpolated SQL in `where`/`find_by_sql` → parameterized (`where("x = ?", v)`) (SQL injection, BLOCKING/security).
+- Mass-assignment without strong params; trusting `params` directly into `update`/`create` (BLOCKING).
+- N+1 queries: association accessed in a loop without `includes`/`preload`.
+- `rescue => e` that swallows or `rescue nil`; rescuing `Exception` (catches signals).
+- Callbacks with side effects (emails, external calls) that make the model untestable / fire on every save.
+- `save` without checking the return / `save!` where a soft failure is expected (and vice-versa).
+- Time without zone (`Time.now`) → `Time.current`/`Time.zone.now`.
+
+## Correctness
+- `nil` handling: `&.` where a chain can be nil; `present?`/`blank?` vs truthiness.
+- Money as float (BLOCKING) → integer cents / `BigDecimal`.
+- Authorization checked per action (scoped to current_user/tenant), not just authentication.
+- Strong-params permit lists match what the action actually needs (no over-permit).
+
+## Idioms
+- Skinny controllers, logic in services/POROs; query objects over fat scopes.
+- Guard clauses over nested conditionals; predicate methods end in `?`.
+
+## Tests
+- RSpec/Minitest for new behavior incl. validation + authorization failure paths.
+- Avoid testing through mocks only; exercise the real object where cheap.

--- a/maggy/maggy/review/skills/rust.md
+++ b/maggy/maggy/review/skills/rust.md
@@ -1,0 +1,24 @@
+# Review skill — Rust
+
+## Anti-patterns — flag on sight
+- `.unwrap()` / `.expect()` on a fallible path that can run in production → propagate with `?` or handle (BLOCKING in library/server code).
+- `panic!`/`unreachable!`/`todo!` left on a reachable path (BLOCKING).
+- `unsafe` blocks without a `// SAFETY:` justification, or that break aliasing/lifetime invariants (BLOCKING — scrutinize hard).
+- `.clone()` to silence the borrow checker where a borrow would do (perf/intent smell).
+- Blocking calls (`std::fs`, `std::net`, `thread::sleep`) inside an async task → use the async runtime equivalents.
+- `.lock().unwrap()` holding a `MutexGuard` across an `.await` (deadlock risk).
+
+## Correctness & ownership
+- Integer overflow in arithmetic on untrusted input → `checked_*`/`saturating_*` (overflow panics in debug, wraps in release).
+- `as` casts that truncate/sign-flip silently → `try_into()`.
+- Error types: a real `enum` error or `anyhow`/`thiserror`, not `Box<dyn Error>` everywhere losing context.
+- Lifetimes that leak implementation; `'static` bounds added just to compile.
+- `Drop` order / RAII assumptions; resources released on every path (incl. early `?`).
+
+## Idioms
+- Prefer iterators/combinators over manual index loops; `if let`/`match` exhaustiveness.
+- Make illegal states unrepresentable (newtypes, enums) rather than runtime checks.
+
+## Tests
+- `#[test]` for new behavior incl. the `Err` arms; `#[should_panic]` only for genuine invariants.
+- Run with the same features the change touches; doctests compile.

--- a/maggy/maggy/review/skills/typescript.md
+++ b/maggy/maggy/review/skills/typescript.md
@@ -1,0 +1,29 @@
+# Review skill — TypeScript / React (frontend-app)
+
+## FE-specific rules
+1. **New features MUST be feature-flagged.** Any net-new user-facing feature
+   (route, page, panel, drawer, widget) must be gated behind a flag —
+   `useFeatureFlag('...')` or a `VITE_FF_*` env flag — so it is NOT shipped to all
+   users by default. A new feature entry point with no flag gate is **BLOCKING**;
+   cite the ungated mount/route `file:line`. (Bug fixes / changes to already-shipped
+   features don't need a new flag.)
+2. **i18n: both `de` AND `en`, German INFORMAL.** Every new user-facing string
+   needs keys in BOTH the `en` and `de` locale files — no hardcoded literals in
+   components. German MUST use **du/dein/deine**, never **Sie/Ihr/Ihre**. Use ICU
+   `{count}`, never legacy `{{count}}`. Missing `de` key, hardcoded string, or
+   formal German = **BLOCKING**. (Verify with `grep` against the locale JSON.)
+3. **Follow FE guidelines** (`docs/`): Nx lib boundaries (no
+   `@nx/enforce-module-boundaries` violations unless an explicit, justified
+   `eslint-disable`), TypeScript strictness (no stray `any`), feature/lib layering,
+   no secrets in client-exposed `VITE_*` / `NEXT_PUBLIC_*` / `REACT_APP_*`,
+   accessible + i18n'd UI, and tests for new logic.
+
+## Correctness
+- `useEffect` deps, stale closures, missing cleanup; unbounded re-renders.
+- `any`/unsafe casts hiding type errors; non-null `!` on possibly-undefined values.
+- Async: unhandled promise rejections, race conditions on rapid state updates.
+- Accessibility: interactive elements need roles/labels; keyboard support.
+
+## Verify, don't assume
+- To check a flag/translation/import, `grep` the locale JSON or the file — don't
+  infer from the diff alone (a key may already exist in an unchanged file).

--- a/maggy/maggy/review/static_check.py
+++ b/maggy/maggy/review/static_check.py
@@ -1,0 +1,153 @@
+"""Deterministic static gate — the part the LLM council structurally can't do.
+
+The council reads diffs; it never COMPILES. So an out-of-scope variable (runtime
+ReferenceError), a type error, or a syntax error sails straight through. This runs
+the real compiler/linter on the PR's code and turns its output into findings.
+
+Ground truth: these findings skip the refute pass (you can't "refute" tsc) and are
+filtered to the PR's CHANGED files so we report regressions, not pre-existing debt.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import subprocess
+from pathlib import Path
+
+from .models import Finding, Severity
+
+# tsc:  path(line,col): error TS1234: message
+_TS = re.compile(r"^(?P<file>[^()\n]+?)\((?P<line>\d+),\d+\): error (?P<code>TS\d+): (?P<msg>.+)$")
+# ruff concise:  path:line:col: CODE message
+_RUFF = re.compile(r"^(?P<file>[^:\n]+):(?P<line>\d+):\d+: (?P<code>[A-Z]+\d+) (?P<msg>.+)$")
+
+# ruff rules that are real bugs (the Python analogue of the zennyEnabled crash),
+# not style. F821 = undefined name; E9 = syntax; F82x = undefined export/__all__.
+_RUFF_SELECT = "E9,F821,F822,F823,F811,F406,F501,F502,F522,F601,F602,F631,F701,F702"
+
+
+def _run(cmd, cwd, timeout=600):
+    try:
+        r = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout)
+        return (r.stdout or "") + "\n" + (r.stderr or "")
+    except Exception as e:  # noqa: BLE001
+        return f"__TOOL_ERROR__ {type(e).__name__}: {e}"
+
+
+def _norm(p: str) -> str:
+    p = p.strip().replace("\\", "/").lstrip("./")
+    while p.startswith("../"):
+        p = p[3:]
+    return p
+
+
+def _match_changed(err_path: str, changed: set[str]) -> str | None:
+    """tsc/ruff paths can be project-relative (../../libs/...); match by path suffix
+    against the PR's changed files so we only report errors the PR is responsible for."""
+    e = _norm(err_path)
+    for c in changed:
+        if c == e or c.endswith("/" + e) or e.endswith("/" + c) or e.endswith(c):
+            return c
+    return None
+
+
+def _finding(file, line, code, msg, tool):
+    return Finding(
+        file=file,
+        line=int(line) if line else None,
+        severity=Severity.blocking,
+        title=f"{tool}: {code} — {msg[:90]}",
+        detail=f"Deterministic {tool} error on a changed line: {code} {msg}. "
+               f"This is a compiler/linter error (not an opinion) and will break the build "
+               f"or crash at runtime — it must be fixed before merge.",
+        evidence=f"static analysis ({tool})",
+    )
+
+
+def _ts_gate(lp: Path, changed_ts: set[str], on_log) -> list[Finding]:
+    files_arg = ",".join(sorted(changed_ts))
+    proj = _run(["npx", "nx", "show", "projects", "--affected", "--files=" + files_arg], lp, 120)
+    projects = [p.strip() for p in proj.splitlines()
+                if p.strip() and not p.strip().endswith("-e2e") and "__TOOL_ERROR__" not in p]
+    if not projects:
+        on_log("[static] ts: no affected nx projects resolved; skipping typecheck")
+        return []
+    on_log(f"[static] ts: typecheck {projects}")
+    out = _run(["npx", "nx", "run-many", "-t", "typecheck", "-p", *projects, "--skip-nx-cache"], lp, 600)
+    if out.startswith("__TOOL_ERROR__"):
+        on_log(f"[static] ts: typecheck did not run ({out[:80]})")
+        return []
+    found, seen = [], set()
+    for ln in out.splitlines():
+        m = _TS.match(ln.strip())
+        if not m:
+            continue
+        # TS5xxx/TS6xxx are nx/tsconfig PROJECT-CONFIG errors (e.g. TS6307 "file not
+        # listed in project"), not code bugs — skip them. Real code errors are TS1xxx
+        # (syntax) and TS2xxx/TS7xxx/TS18xxx (type/undefined-name).
+        if m.group("code").startswith(("TS5", "TS6")):
+            continue
+        cf = _match_changed(m.group("file"), changed_ts)
+        if not cf:
+            continue  # error in a file this PR didn't change -> pre-existing, not ours
+        key = (cf, m.group("line"), m.group("code"))
+        if key in seen:
+            continue
+        seen.add(key)
+        found.append(_finding(cf, m.group("line"), m.group("code"), m.group("msg"), "tsc"))
+    return found
+
+
+def _py_gate(lp: Path, changed_py: set[str], on_log) -> list[Finding]:
+    existing = [c for c in sorted(changed_py) if (lp / c).exists()]
+    if not existing:
+        return []
+    on_log(f"[static] py: ruff (bug rules) on {len(existing)} changed file(s)")
+    out = _run(["ruff", "check", "--select", _RUFF_SELECT, "--output-format", "concise",
+                "--no-cache", *existing], lp, 180)
+    if out.startswith("__TOOL_ERROR__"):
+        on_log(f"[static] py: ruff did not run ({out[:80]})")
+        return []
+    found, seen = [], set()
+    for ln in out.splitlines():
+        m = _RUFF.match(ln.strip())
+        if not m:
+            continue
+        cf = _match_changed(m.group("file"), changed_py) or _norm(m.group("file"))
+        key = (cf, m.group("line"), m.group("code"))
+        if key in seen:
+            continue
+        seen.add(key)
+        found.append(_finding(cf, m.group("line"), m.group("code"), m.group("msg"), "ruff"))
+    return found
+
+
+async def run_static_gate(deps, langs, on_log) -> list[Finding]:
+    """Run the deterministic compiler/linter gate against the local checkout.
+    Returns blocking findings for errors on the PR's changed files (empty if no
+    local checkout, tooling missing, or nothing to check)."""
+    lp = deps.local_path
+    if not lp:
+        on_log("[static] skipped — no local checkout (--repo-path)")
+        return []
+    lp = Path(lp)
+    changed = {f["filename"] for f in deps.files}
+    # caveat if the local tree isn't exactly the PR head (best-effort, still useful)
+    head = _run(["git", "rev-parse", "HEAD"], lp, 20).strip().splitlines()[0:1]
+    if head and head[0] and head[0] != deps.head_sha:
+        on_log(f"[static] note: local HEAD {head[0][:8]} != PR head {deps.head_sha[:8]} "
+               "— gate runs against the local checkout")
+
+    def _work():
+        out: list[Finding] = []
+        ts = {c for c in changed if c.endswith((".ts", ".tsx"))}
+        py = {c for c in changed if c.endswith(".py")}
+        if "typescript" in langs and ts:
+            out += _ts_gate(lp, ts, on_log)
+        if "python" in langs and py:
+            out += _py_gate(lp, py, on_log)
+        return out
+
+    findings = await asyncio.to_thread(_work)
+    on_log(f"[static] {len(findings)} deterministic error(s) on changed files")
+    return findings

--- a/maggy/maggy/review/static_check.py
+++ b/maggy/maggy/review/static_check.py
@@ -99,12 +99,14 @@ def _ts_gate(lp: Path, changed_ts: set[str], on_log) -> list[Finding]:
 
 
 def _py_gate(lp: Path, changed_py: set[str], on_log) -> list[Finding]:
-    existing = [c for c in sorted(changed_py) if (lp / c).exists()]
+    # changed_py are PR-controlled filenames; drop any leading-dash path so it
+    # can't be smuggled to ruff as a flag, and terminate options with `--`.
+    existing = [c for c in sorted(changed_py) if (lp / c).exists() and not c.startswith("-")]
     if not existing:
         return []
     on_log(f"[static] py: ruff (bug rules) on {len(existing)} changed file(s)")
     out = _run(["ruff", "check", "--select", _RUFF_SELECT, "--output-format", "concise",
-                "--no-cache", *existing], lp, 180)
+                "--no-cache", "--", *existing], lp, 180)
     if out.startswith("__TOOL_ERROR__"):
         on_log(f"[static] py: ruff did not run ({out[:80]})")
         return []

--- a/maggy/maggy/review/tools.py
+++ b/maggy/maggy/review/tools.py
@@ -67,10 +67,14 @@ def register_tools(agent):
         lp = ctx.deps.local_path
         if not lp or not Path(lp).exists():
             return "(local repo not available for grep — use read_file on a specific path instead)"
+        # pattern/path_glob are model-controlled (and the model can be
+        # prompt-injected via the diff). Terminate options with `--` so a
+        # leading-dash value can't be smuggled to grep as a flag.
         cmd = ["grep", "-rnI", "--exclude-dir=.git", "--exclude-dir=node_modules",
-               "--exclude-dir=.venv", "-E", pattern, str(lp)]
+               "--exclude-dir=.venv", "-E"]
         if path_glob:
-            cmd[1:1] = [f"--include={path_glob}"]
+            cmd.append(f"--include={path_glob}")
+        cmd += ["--", pattern, str(lp)]
         try:
             out = subprocess.run(cmd, capture_output=True, text=True, timeout=30).stdout
         except Exception as e:  # noqa: BLE001

--- a/maggy/maggy/review/tools.py
+++ b/maggy/maggy/review/tools.py
@@ -1,0 +1,98 @@
+"""Tools the reviewer/planner agents call to VERIFY against the real repo
+instead of guessing — the core fix for the false-positive class."""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic_ai import RunContext
+
+from . import github
+
+
+@dataclass
+class ReviewDeps:
+    token: str
+    owner: str
+    repo: str
+    head_sha: str
+    files: list[dict]                       # PR files (filename, patch, additions, deletions, status)
+    local_path: Path | None = None          # local checkout for fast grep (optional)
+    mcp_bin: str = ""                        # codebase-memory-mcp for query_icpg (optional)
+    _cache: dict = field(default_factory=dict)
+
+
+def register_tools(agent):
+    """Attach the shared repo toolset to a Pydantic AI agent."""
+
+    @agent.tool
+    def list_changed_files(ctx: RunContext[ReviewDeps]) -> str:
+        """List the files changed in this PR with +/- line counts and status."""
+        return "\n".join(
+            f"{f['filename']} ({f.get('status','')}, +{f.get('additions',0)}/-{f.get('deletions',0)})"
+            for f in ctx.deps.files
+        ) or "(no files)"
+
+    @agent.tool
+    def get_diff(ctx: RunContext[ReviewDeps], path: str) -> str:
+        """Get the unified diff (patch) for one changed file."""
+        for f in ctx.deps.files:
+            if f["filename"] == path:
+                return f.get("patch") or "(no textual patch — binary or too large)"
+        return f"(no diff: {path} is not in this PR)"
+
+    @agent.tool
+    def read_file(ctx: RunContext[ReviewDeps], path: str) -> str:
+        """Read the FULL current contents of a file at the PR head (to see
+        unchanged code: helper definitions, imports, neighbours). Use this before
+        claiming a symbol is undefined or a file is incomplete."""
+        key = f"read:{path}"
+        if key in ctx.deps._cache:
+            return ctx.deps._cache[key]
+        try:
+            txt = github.get_file_at(ctx.deps.token, ctx.deps.owner, ctx.deps.repo, path, ctx.deps.head_sha)
+        except Exception as e:  # noqa: BLE001
+            txt = f"(could not read {path}: {e})"
+        if len(txt) > 18000:
+            txt = txt[:18000] + "\n... [truncated; ask for a grep if you need a later part] ..."
+        ctx.deps._cache[key] = txt
+        return txt
+
+    @agent.tool
+    def grep(ctx: RunContext[ReviewDeps], pattern: str, path_glob: str = "") -> str:
+        """Search the repo for a regex (e.g. a symbol/def, a translation key, an
+        import). Authoritative way to check whether something exists in unchanged
+        code. Returns matching `file:line: text` lines."""
+        lp = ctx.deps.local_path
+        if not lp or not Path(lp).exists():
+            return "(local repo not available for grep — use read_file on a specific path instead)"
+        cmd = ["grep", "-rnI", "--exclude-dir=.git", "--exclude-dir=node_modules",
+               "--exclude-dir=.venv", "-E", pattern, str(lp)]
+        if path_glob:
+            cmd[1:1] = [f"--include={path_glob}"]
+        try:
+            out = subprocess.run(cmd, capture_output=True, text=True, timeout=30).stdout
+        except Exception as e:  # noqa: BLE001
+            return f"(grep failed: {e})"
+        lines = [ln.replace(str(lp) + "/", "") for ln in out.splitlines()][:40]
+        return "\n".join(lines) or f"(no matches for /{pattern}/)"
+
+    @agent.tool
+    def read_adr(ctx: RunContext[ReviewDeps], query: str) -> str:
+        """Search the repo's docs/ADRs for an Accepted decision before flagging or
+        clearing an ADR concern. Returns matching ADR files + lines."""
+        lp = ctx.deps.local_path
+        if not lp:
+            return "(local repo not available)"
+        adr_dir = Path(lp) / "docs/ADRs"
+        if not adr_dir.exists():
+            return "(no docs/ADRs/ in this repo)"
+        hits = []
+        for p in sorted(adr_dir.glob("*.md")):
+            for i, ln in enumerate(p.read_text(errors="replace").splitlines(), 1):
+                if query.lower() in ln.lower():
+                    hits.append(f"{p.name}:{i}: {ln.strip()[:120]}")
+        return "\n".join(hits[:30]) or f"(no ADR mentions '{query}')"
+
+    return agent

--- a/maggy/maggy/static/app.js
+++ b/maggy/maggy/static/app.js
@@ -165,6 +165,7 @@ function switchTab(tab, fromHash) {
   else if (tab === 'routing') loadRouting();
   else if (tab === 'budget') loadBudget();
   else if (tab === 'forge') loadForge();
+  else if (tab === 'pr-review') loadPrReview();
   else if (tab === 'logs') loadLogs();
   else if (tab === 'skills') loadSkills();
   else if (tab === 'settings') loadSettings();
@@ -2493,6 +2494,105 @@ function srooterMsg(el, text, isErr) {
   if (!el) return;
   el.textContent = text;
   el.className = `text-[10px] ${isErr ? 'text-red-400' : 'text-green-400'}`;
+}
+
+// ---- PR Review: agentic council reviewer (maggy.review) --------------------
+
+async function loadPrReview() {
+  const pane = document.getElementById('pane-pr-review');
+  if (!pane) return;
+  pane.innerHTML = `<h2 class="text-sm font-bold text-white mb-3"><i class="fas fa-scale-balanced mr-1"></i>PR Review — agentic council</h2>
+    <div id="prr-status" class="text-[10px] text-gray-500 mb-3"><i class="fas fa-spinner fa-spin mr-1"></i>Checking reviewer…</div>
+    <div class="card p-4 mb-3">
+      <div class="grid grid-cols-2 gap-3 text-[11px]">
+        <div><label class="text-[9px] text-gray-500 uppercase block mb-0.5">Repo (owner/repo)</label>
+          <input id="prr-repo" class="w-full px-2 py-1 rounded text-xs" style="background:var(--bg-card);color:var(--text);border:1px solid var(--border)" placeholder="zenloopGmbH/surveys-backend"></div>
+        <div><label class="text-[9px] text-gray-500 uppercase block mb-0.5">PR number</label>
+          <input id="prr-num" type="number" class="w-full px-2 py-1 rounded text-xs" style="background:var(--bg-card);color:var(--text);border:1px solid var(--border)" placeholder="525"></div>
+        <div><label class="text-[9px] text-gray-500 uppercase block mb-0.5">GitHub token (optional — overrides default)</label>
+          <input id="prr-token" type="password" class="w-full px-2 py-1 rounded text-xs" style="background:var(--bg-card);color:var(--text);border:1px solid var(--border)" placeholder="ghp_… (blank = use configured/env)"></div>
+        <div><label class="text-[9px] text-gray-500 uppercase block mb-0.5">Local checkout path (optional — enables static gate)</label>
+          <input id="prr-path" class="w-full px-2 py-1 rounded text-xs" style="background:var(--bg-card);color:var(--text);border:1px solid var(--border)" placeholder="~/Documents/…"></div>
+      </div>
+      <div class="flex gap-2 items-center mt-3">
+        <label class="text-[10px] text-gray-400 flex items-center gap-1"><input type="checkbox" id="prr-dry" checked> Dry-run (don't post to GitHub)</label>
+        <span class="flex-1"></span>
+        <button onclick="runPrReview()" class="btn btn-primary text-[10px]" id="prr-btn"><i class="fas fa-play mr-1"></i>Run council</button>
+      </div>
+      <div id="prr-msg" class="text-[10px] hidden mt-2"></div>
+    </div>
+    <div id="prr-result"></div>`;
+  loadPrReviewStatus();
+}
+
+async function loadPrReviewStatus() {
+  const el = document.getElementById('prr-status');
+  if (!el) return;
+  try {
+    const s = await api('/pr-review/status');
+    if (!s.installed) {
+      el.innerHTML = `<span class="text-yellow-500">Reviewer not installed.</span> ${esc(s.hint || '')}`;
+      return;
+    }
+    const models = (s.models || []).join(', ') || 'none (set provider keys)';
+    const tok = s.token_configured ? '<span class="text-green-400">token ✓</span>' : '<span class="text-red-400">no token</span>';
+    el.innerHTML = `Models: <span class="text-gray-300">${esc(models)}</span> · ${tok} · ${(s.languages || []).length} languages`;
+  } catch (e) {
+    el.innerHTML = `<span class="text-red-400">Status failed: ${esc(e.message)}</span>`;
+  }
+}
+
+async function runPrReview() {
+  const repo = (document.getElementById('prr-repo').value || '').trim();
+  const num = parseInt(document.getElementById('prr-num').value, 10);
+  const msg = document.getElementById('prr-msg');
+  if (!repo.includes('/') || !num) { prrMsg(msg, 'Enter owner/repo and a PR number.', true); return; }
+  const [owner, name] = repo.split('/', 2);
+  const body = {
+    owner: owner, repo: name, pr_number: num,
+    dry_run: document.getElementById('prr-dry').checked,
+    github_token: (document.getElementById('prr-token').value || '').trim() || null,
+    repo_path: (document.getElementById('prr-path').value || '').trim() || null
+  };
+  const btn = document.getElementById('prr-btn');
+  btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i>Reviewing… (may take a minute)';
+  if (msg) msg.classList.add('hidden');
+  try {
+    const r = await api('/pr-review/run', { method: 'POST', body: JSON.stringify(body) });
+    document.getElementById('prr-result').innerHTML = renderPrReview(r);
+  } catch (e) {
+    prrMsg(msg, e.message, true);
+  } finally {
+    btn.disabled = false; btn.innerHTML = '<i class="fas fa-play mr-1"></i>Run council';
+  }
+}
+
+function renderPrReview(r) {
+  const ok = r.decision === 'approve';
+  const badge = ok ? '<span class="text-green-400">✅ Approve</span>' : '<span class="text-red-400">🛑 Changes requested</span>';
+  const cost = r.cost ? `~$${(r.cost.total_usd || 0).toFixed(3)}` : '';
+  let h = `<div class="card p-4">
+    <div class="flex items-center gap-2 mb-2 text-[11px]">${badge}
+      <span class="text-gray-600">blast ${esc(String(r.blast_radius || '?'))} · ${(r.findings || []).length} findings · ${esc(cost)}${r.dry_run ? ' · dry-run' : ''}</span></div>
+    <div class="text-[11px] text-gray-300 mb-3">${esc(r.summary || '')}</div>`;
+  for (const f of (r.findings || [])) {
+    const tag = f.severity === 'blocking' ? '🔴' : '🟡';
+    h += `<div class="mb-2 p-2 rounded" style="background:var(--bg-secondary)">
+      <div class="text-[11px] text-white">${tag} <span class="text-gray-400">${esc(f.file || '')}${f.line ? ':' + f.line : ''}</span> — <b>${esc(f.title || '')}</b></div>
+      <div class="text-[10px] text-gray-400 mt-0.5">${esc(f.detail || '')}</div></div>`;
+  }
+  if (r.logs && r.logs.length) {
+    h += `<details class="mt-2"><summary class="text-[10px] text-gray-500 cursor-pointer">Run log (${r.logs.length})</summary>
+      <pre class="text-[9px] text-gray-500 mt-1 whitespace-pre-wrap">${esc(r.logs.join('\n'))}</pre></details>`;
+  }
+  return h + '</div>';
+}
+
+function prrMsg(el, text, isErr) {
+  if (!el) return;
+  el.textContent = text;
+  el.className = `text-[10px] ${isErr ? 'text-red-400' : 'text-green-400'}`;
+  el.classList.remove('hidden');
 }
 
 async function runModelHealthCheck() {

--- a/maggy/maggy/static/index.html
+++ b/maggy/maggy/static/index.html
@@ -161,6 +161,7 @@
     <div class="sidebar-section">System</div>
     <nav class="flex-1 flex flex-col gap-0.5 overflow-y-auto scroll-thin">
       <a href="#" onclick="switchTab('forge')" data-tab="forge" class="sidebar-link"><i class="fas fa-hammer"></i><span>Forge</span></a>
+      <a href="#" onclick="switchTab('pr-review')" data-tab="pr-review" class="sidebar-link"><i class="fas fa-scale-balanced"></i><span>PR Review</span></a>
       <a href="#" onclick="switchTab('logs')" data-tab="logs" class="sidebar-link"><i class="fas fa-scroll"></i><span>Logs</span></a>
       <a href="#" onclick="switchTab('settings')" data-tab="settings" class="sidebar-link"><i class="fas fa-gear"></i><span>Settings</span></a>
     </nav>
@@ -221,6 +222,7 @@
       <div id="pane-routing" class="h-full p-4 hidden"></div>
       <div id="pane-budget" class="h-full p-4 hidden"></div>
       <div id="pane-forge" class="h-full p-4 hidden"></div>
+      <div id="pane-pr-review" class="h-full p-4 hidden overflow-y-auto"></div>
       <div id="pane-logs" class="h-full hidden">
         <div class="pane-content">
           <div class="flex items-center gap-2 mb-4">

--- a/maggy/pyproject.toml
+++ b/maggy/pyproject.toml
@@ -41,10 +41,14 @@ dependencies = [
 docs = ["openpyxl>=3.1", "python-docx>=1.0", "pymupdf>=1.24"]
 reddit = ["asyncpraw>=7.7"]          # build-in-public Reddit agent
 screenshots = ["playwright>=1.40"]   # dashboard/screenshot capture
-review = ["pydantic-ai>=1.0"]        # agentic council PR reviewer (maggy.review)
+# Agentic council PR reviewer (maggy.review). Provider SDKs cover the default
+# roster: google-genai (Gemini chair/reviewer) + openai (GPT, and the
+# OpenAI-compatible DeepSeek/Grok seats). Add groq/anthropic for those seats.
+review = ["pydantic-ai>=1.0", "google-genai>=2.0", "openai>=1.40"]
 all = [
     "openpyxl>=3.1", "python-docx>=1.0", "pymupdf>=1.24",
-    "asyncpraw>=7.7", "playwright>=1.40", "pydantic-ai>=1.0",
+    "asyncpraw>=7.7", "playwright>=1.40",
+    "pydantic-ai>=1.0", "google-genai>=2.0", "openai>=1.40",
 ]
 
 [project.urls]

--- a/maggy/pyproject.toml
+++ b/maggy/pyproject.toml
@@ -41,9 +41,10 @@ dependencies = [
 docs = ["openpyxl>=3.1", "python-docx>=1.0", "pymupdf>=1.24"]
 reddit = ["asyncpraw>=7.7"]          # build-in-public Reddit agent
 screenshots = ["playwright>=1.40"]   # dashboard/screenshot capture
+review = ["pydantic-ai>=1.0"]        # agentic council PR reviewer (maggy.review)
 all = [
     "openpyxl>=3.1", "python-docx>=1.0", "pymupdf>=1.24",
-    "asyncpraw>=7.7", "playwright>=1.40",
+    "asyncpraw>=7.7", "playwright>=1.40", "pydantic-ai>=1.0",
 ]
 
 [project.urls]

--- a/maggy/tests/test_review_languages.py
+++ b/maggy/tests/test_review_languages.py
@@ -1,0 +1,86 @@
+"""Tests for the extensible language registry + token resolution (no heavy deps)."""
+
+from __future__ import annotations
+
+import pytest
+
+from maggy.review import config as review_config
+from maggy.review import languages as lang
+
+
+@pytest.fixture(autouse=True)
+def _restore_registry():
+    """Snapshot/restore REGISTRY so register tests don't leak."""
+    saved = dict(lang.REGISTRY)
+    yield
+    lang.REGISTRY.clear()
+    lang.REGISTRY.update(saved)
+
+
+class TestDetect:
+    def test_detects_by_extension(self):
+        files = ["app/main.py", "web/x.tsx", "svc/h.go", "lib/a.rs"]
+        assert lang.detect_languages(files) == ["go", "python", "rust", "typescript"]
+
+    def test_db_by_path_marker(self):
+        assert "db" in lang.detect_languages(["migrations/0001_init.py"])
+        assert "db" in lang.detect_languages(["db/schema.sql"])
+
+    def test_seeded_common_set_present(self):
+        for name in ("go", "rust", "java", "csharp", "ruby", "php"):
+            assert name in lang.supported()
+
+    def test_unknown_extension_ignored(self):
+        assert lang.detect_languages(["README.md", "logo.png"]) == []
+
+
+class TestSkillLoading:
+    def test_base_always_loads(self):
+        out = lang.load_skill([])
+        assert "review skill" in out.lower() or len(out) > 0
+
+    def test_per_language_skill_appended(self):
+        out = lang.load_skill(["go"])
+        assert "Go" in out
+
+    def test_unknown_language_skipped_not_crash(self):
+        out = lang.load_skill(["klingon"])  # no skill file -> just base
+        assert isinstance(out, str)
+
+
+class TestExtensibility:
+    def test_register_language(self):
+        lang.register_language(lang.Language("kotlin", (".kt", ".kts")))
+        assert "kotlin" in lang.supported()
+        assert "kotlin" in lang.detect_languages(["app/Main.kt"])
+
+    def test_load_from_config(self):
+        added = lang.load_from_config([{"name": "scala", "extensions": [".scala"]}])
+        assert added == ["scala"]
+        assert "scala" in lang.detect_languages(["x.scala"])
+
+    def test_load_from_config_skips_malformed(self):
+        added = lang.load_from_config([{"no_name": True}, {"name": "elixir", "extensions": [".ex"]}])
+        assert added == ["elixir"]
+
+
+class TestTokenResolution:
+    def test_override_wins(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "env_tok")
+        assert review_config.resolve_token("override", "config_tok") == "override"
+
+    def test_config_beats_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "env_tok")
+        assert review_config.resolve_token(None, "config_tok") == "config_tok"
+
+    def test_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "env_tok")
+        assert review_config.resolve_token(None, "") == "env_tok"
+
+    def test_none_when_nothing(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert review_config.resolve_token(None, "") is None
+
+    def test_whitespace_ignored(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert review_config.resolve_token("   ", "  ") is None

--- a/maggy/tests/test_review_pipeline.py
+++ b/maggy/tests/test_review_pipeline.py
@@ -1,0 +1,64 @@
+"""Tests for the vendored deterministic review helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from maggy.review.config import cost_usd
+from maggy.review.github import valid_comment_lines
+from maggy.review.static_check import _match_changed, _norm
+
+
+class TestValidCommentLines:
+    def test_added_lines_only(self):
+        patch = "@@ -1,3 +1,4 @@\n ctx\n-old\n+new1\n+new2\n ctx2"
+        assert valid_comment_lines(patch) == {2, 3}
+
+    def test_empty_patch(self):
+        assert valid_comment_lines("") == set()
+
+    def test_context_increments_line(self):
+        patch = "@@ -1,2 +1,3 @@\n a\n+b\n c"
+        assert 2 in valid_comment_lines(patch)  # the added 'b' is new line 2
+
+
+class TestMatchChanged:
+    def test_suffix_match_strips_relative_prefix(self):
+        changed = {"libs/shared/a.ts", "apps/app/b.py"}
+        assert _match_changed("../../libs/shared/a.ts", changed) == "libs/shared/a.ts"
+
+    def test_no_match_returns_none(self):
+        assert _match_changed("unrelated/c.ts", {"libs/a.ts"}) is None
+
+    def test_norm_strips_dotdot_and_backslashes(self):
+        assert _norm("..\\..\\libs\\a.ts") == "libs/a.ts"
+
+
+class TestCostUsd:
+    def test_unknown_model_is_free(self):
+        assert cost_usd("nope", 1000, 1000) == 0.0
+
+    def test_basic_cost(self):
+        # gpt-5.5: 15/M in, 120/M out -> 100k in + 10k out = 1.5 + 1.2
+        assert round(cost_usd("gpt-5.5", 100_000, 10_000, 0), 3) == 2.7
+
+    def test_cache_discount_applied(self):
+        full = cost_usd("gemini-3.5", 100_000, 0, 0)
+        cached = cost_usd("gemini-3.5", 100_000, 0, 100_000)
+        assert cached < full  # cached input billed at 25%
+
+
+class TestDecompose:
+    def test_small_pr_single_chunk(self):
+        pytest.importorskip("pydantic_ai")
+        from maggy.review.pipeline import decompose
+        files = [{"filename": f"app/a{i}.py"} for i in range(5)]
+        assert len(decompose(files, ["python"])) == 1
+
+    def test_large_pr_bounded_chunks(self):
+        pytest.importorskip("pydantic_ai")
+        from maggy.review.pipeline import MAX_CHUNK_FILES, decompose
+        files = [{"filename": f"libs/x/y/z/f{i}.ts"} for i in range(20)]
+        chunks = decompose(files, ["typescript"])
+        assert len(chunks) > 1
+        assert max(len(c.files) for c in chunks) <= MAX_CHUNK_FILES

--- a/maggy/tests/test_review_pipeline.py
+++ b/maggy/tests/test_review_pipeline.py
@@ -21,6 +21,12 @@ class TestValidCommentLines:
         patch = "@@ -1,2 +1,3 @@\n a\n+b\n c"
         assert 2 in valid_comment_lines(patch)  # the added 'b' is new line 2
 
+    def test_no_newline_marker_not_counted(self):
+        # "\ No newline at end of file" must not advance the line counter
+        patch = "@@ -1,1 +1,2 @@\n a\n+b\n\\ No newline at end of file\n+c"
+        # a(ctx)=line1, +b=line2, marker skipped, +c=line3
+        assert valid_comment_lines(patch) == {2, 3}
+
 
 class TestMatchChanged:
     def test_suffix_match_strips_relative_prefix(self):

--- a/maggy/tests/test_routes_pr_review.py
+++ b/maggy/tests/test_routes_pr_review.py
@@ -1,0 +1,82 @@
+"""Tests for /api/pr-review/* routes."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from maggy.config import MaggyConfig
+from maggy.review.models import BlastRadius, Finding, ReviewPlan, Severity, Verdict
+
+
+@pytest.fixture()
+def client():
+    from maggy.main import create_app
+    app = create_app()
+    app.state.cfg = MaggyConfig()
+    return TestClient(app)
+
+
+def _fake_out():
+    plan = ReviewPlan(blast_radius=BlastRadius(size="small"), council_size=2)
+    finding = Finding(file="a.py", line=3, severity=Severity.blocking, title="bug", detail="x")
+    final = Verdict(decision="changes_needed", summary="needs work", findings=[finding])
+    return {"plan": plan, "chunks": [1], "final": final, "post": {"dry_run": True}, "cost": {"total_usd": 0.1}}
+
+
+class TestLanguages:
+    def test_lists_supported(self, client):
+        resp = client.get("/api/pr-review/languages")
+        assert resp.status_code == 200
+        langs = resp.json()["languages"]
+        assert {"python", "typescript", "go", "rust", "php"} <= set(langs)
+
+
+class TestStatus:
+    def test_status_shape(self, client):
+        resp = client.get("/api/pr-review/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "installed" in body and "languages" in body and "token_configured" in body
+
+
+class TestRun:
+    def test_missing_token_400(self, client, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        resp = client.post("/api/pr-review/run",
+                           json={"owner": "o", "repo": "r", "pr_number": 1})
+        assert resp.status_code == 400
+
+    def test_run_serializes_verdict(self, client, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+
+        async def fake_run(owner, repo, num, **kw):
+            assert kw["token"] == "tok"
+            return _fake_out()
+
+        with patch("maggy.review.pipeline.run_review", side_effect=fake_run):
+            resp = client.post("/api/pr-review/run",
+                               json={"owner": "o", "repo": "r", "pr_number": 7})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["decision"] == "changes_needed"
+        assert body["dry_run"] is True
+        assert len(body["findings"]) == 1
+        assert body["findings"][0]["file"] == "a.py"
+
+    def test_per_request_token_override(self, client, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        seen = {}
+
+        async def fake_run(owner, repo, num, **kw):
+            seen["token"] = kw["token"]
+            return _fake_out()
+
+        with patch("maggy.review.pipeline.run_review", side_effect=fake_run):
+            resp = client.post("/api/pr-review/run",
+                               json={"owner": "o", "repo": "r", "pr_number": 7,
+                                     "github_token": "override_tok"})
+        assert resp.status_code == 200
+        assert seen["token"] == "override_tok"


### PR DESCRIPTION
Vendors revir's council PR-review pipeline into Maggy as a first-class module (`maggy/maggy/review/`), adds an extensible language-skill registry (seeds go/rust/java/csharp/ruby/php), makes the GitHub token configurable (per-request > config > env), exposes `/api/pr-review/*`, and adds a PR Review dashboard tab.

`pydantic-ai` is an optional extra (`pip install maggy-harness[review]`), imported lazily. 31 new tests; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “PR Review” dashboard tab with an agentic council PR review experience.
  * Added PR-review API endpoints to list supported languages, check status, and run reviews with optional GitHub token override and local checkout.
  * Introduced extensible, per-language review skills with deterministic mega-PR chunking and structured outputs (decision, findings, blast radius, and cost/meta).

* **Bug Fixes**
  * Hardened static tooling execution against argument flag-smuggling.
  * Fixed diff line counting for inline comments and improved review extra packaging for additional providers.

* **Tests**
  * Added/expanded coverage for routes, language detection, and review-pipeline helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->