### PR TITLE
feat(maggy/review): configure reviewer-bot token from Settings

### DIFF
--- a/maggy/maggy/api/routes_pr_review.py
+++ b/maggy/maggy/api/routes_pr_review.py
@@ -8,6 +8,8 @@ per-request override > Maggy config (review.github_token) > env GITHUB_TOKEN.
 
 from __future__ import annotations
 
+import os
+
 from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel
 
@@ -25,6 +27,27 @@ class RunRequest(BaseModel):
     dry_run: bool | None = None       # None -> fall back to config.review.default_dry_run
     github_token: str | None = None   # per-request override (beats config + env)
     repo_path: str | None = None      # local checkout for the static gate / FP filter
+
+
+class ReviewConfigUpdate(BaseModel):
+    github_token: str | None = None   # set the bot token; None/"" = leave unchanged
+    clear_token: bool = False         # explicitly clear it (fall back to env GITHUB_TOKEN)
+    default_dry_run: bool | None = None
+
+
+def _mask(tok: str) -> str:
+    """Never return a raw token — only a recognizable last-4 hint."""
+    return f"…{tok[-4:]}" if tok and len(tok) >= 4 else ("set" if tok else "")
+
+
+def _config_view(rc) -> dict:
+    """Masked, safe-to-return view of the reviewer config."""
+    return {
+        "token_set": bool(rc.github_token),
+        "token_hint": _mask(rc.github_token),
+        "uses_env_fallback": (not rc.github_token) and bool(os.environ.get("GITHUB_TOKEN")),
+        "default_dry_run": rc.default_dry_run,
+    }
 
 
 def _register_config_languages(cfg) -> None:
@@ -63,6 +86,32 @@ async def status(request: Request, x_api_key: str | None = Header(None)) -> dict
         "token_configured": bool(_resolve_token(cfg, None)),
         "languages": review_languages.supported(),
     }
+
+
+@router.get("/config")
+async def get_config(request: Request, x_api_key: str | None = Header(None)) -> dict:
+    """Reviewer-bot config (masked). The raw token is never returned."""
+    check_auth(request, x_api_key)
+    return _config_view(request.app.state.cfg.review)
+
+
+@router.post("/config")
+async def set_config(
+    request: Request, body: ReviewConfigUpdate, x_api_key: str | None = Header(None),
+) -> dict:
+    """Save the reviewer-bot token / dry-run default to Maggy config."""
+    check_auth(request, x_api_key)
+    cfg = request.app.state.cfg
+    rc = cfg.review
+    if body.clear_token:
+        rc.github_token = ""
+    elif body.github_token is not None and body.github_token.strip():
+        rc.github_token = body.github_token.strip()
+    if body.default_dry_run is not None:
+        rc.default_dry_run = body.default_dry_run
+    from maggy import config as config_mod
+    config_mod.save(cfg)
+    return _config_view(rc)
 
 
 def _serialize(out: dict) -> dict:

--- a/maggy/maggy/static/app.js
+++ b/maggy/maggy/static/app.js
@@ -2261,6 +2261,12 @@ async function loadSettings() {
       <div id="srooter-body" class="text-[10px] text-gray-600"><i class="fas fa-spinner fa-spin mr-1"></i>Checking…</div>
     </div>`;
 
+    // Reviewer bot — GitHub token the council PR reviewer posts with
+    html += `<div class="card p-4 mb-3" id="reviewbot-card">
+      <div class="text-[10px] text-gray-500 uppercase mb-2"><i class="fas fa-robot mr-1"></i>Reviewer Bot (PR review)</div>
+      <div id="reviewbot-body" class="text-[10px] text-gray-600"><i class="fas fa-spinner fa-spin mr-1"></i>Checking…</div>
+    </div>`;
+
     // AI Models section
     const clis = sys.clis || [];
     const installed = clis.filter(c => c.installed);
@@ -2401,6 +2407,7 @@ async function loadSettings() {
     loadCustomModels();
     loadCouncilConfig();
     loadSrooterStatus();
+    loadReviewBot();
   } catch (e) {
     pane.innerHTML = `<div class="card p-4 text-sm text-red-400">Detection failed: ${esc(e.message)}</div>`;
   }
@@ -2593,6 +2600,59 @@ function prrMsg(el, text, isErr) {
   el.textContent = text;
   el.className = `text-[10px] ${isErr ? 'text-red-400' : 'text-green-400'}`;
   el.classList.remove('hidden');
+}
+
+// ---- Reviewer bot token (Settings) -----------------------------------------
+
+async function loadReviewBot() {
+  const body = document.getElementById('reviewbot-body');
+  if (!body) return;
+  try {
+    const c = await api('/pr-review/config');
+    body.innerHTML = renderReviewBot(c);
+  } catch (e) {
+    body.innerHTML = `<span class="text-red-400">Failed: ${esc(e.message)}</span>`;
+  }
+}
+
+function renderReviewBot(c) {
+  let state;
+  if (c.token_set) state = `<span class="text-green-400">Bot token set (${esc(c.token_hint)})</span> — reviews post as the bot.`;
+  else if (c.uses_env_fallback) state = `<span class="text-yellow-500">Using your <code>GITHUB_TOKEN</code> env</span> — reviews post as you (self-review → comment only).`;
+  else state = `<span class="text-red-400">No token</span> — set one below or export <code>GITHUB_TOKEN</code>.`;
+  return `<div class="text-gray-400 mb-2">${state}</div>
+    <div class="text-gray-600 mb-2">Use a dedicated bot account's <a href="https://github.com/settings/tokens/new?scopes=repo&description=maggy-reviewer" target="_blank" class="text-orange-400 hover:underline">Personal Access Token (repo scope)</a> so reviews come from the bot, not you.</div>
+    <div class="space-y-2">
+      <input id="rb-token" type="password" class="w-full px-2 py-1 rounded text-xs" style="background:var(--bg-card);color:var(--text);border:1px solid var(--border)" placeholder="ghp_… bot token (blank = leave unchanged)">
+      <label class="text-[10px] text-gray-400 flex items-center gap-1"><input type="checkbox" id="rb-dry" ${c.default_dry_run ? 'checked' : ''}> Default new reviews to dry-run (don't post)</label>
+      <div class="flex gap-2 items-center">
+        <button onclick="saveReviewBot()" class="btn btn-primary text-[10px]" id="rb-btn"><i class="fas fa-save mr-1"></i>Save</button>
+        ${c.token_set ? '<button onclick="clearReviewBot()" class="btn btn-ghost text-[10px]"><i class="fas fa-trash mr-1"></i>Clear (use env)</button>' : ''}
+        <span id="rb-msg" class="text-[10px] hidden"></span>
+      </div>
+    </div>`;
+}
+
+async function saveReviewBot() {
+  const tok = (document.getElementById('rb-token') || {}).value || '';
+  const dry = document.getElementById('rb-dry').checked;
+  const btn = document.getElementById('rb-btn');
+  const msg = document.getElementById('rb-msg');
+  if (btn) { btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i>Saving…'; }
+  try {
+    const c = await api('/pr-review/config', { method: 'POST', body: JSON.stringify({ github_token: tok.trim() || null, default_dry_run: dry }) });
+    document.getElementById('reviewbot-body').innerHTML = renderReviewBot(c);
+  } catch (e) {
+    if (btn) { btn.disabled = false; btn.innerHTML = '<i class="fas fa-save mr-1"></i>Save'; }
+    prrMsg(msg, e.message, true);
+  }
+}
+
+async function clearReviewBot() {
+  try {
+    const c = await api('/pr-review/config', { method: 'POST', body: JSON.stringify({ clear_token: true }) });
+    document.getElementById('reviewbot-body').innerHTML = renderReviewBot(c);
+  } catch (e) { /* leave UI as-is on error */ }
 }
 
 async function runModelHealthCheck() {

--- a/maggy/tests/test_routes_pr_review.py
+++ b/maggy/tests/test_routes_pr_review.py
@@ -42,6 +42,38 @@ class TestStatus:
         assert "installed" in body and "languages" in body and "token_configured" in body
 
 
+class TestReviewerConfig:
+    def test_get_masks_token(self, client):
+        client.app.state.cfg.review.github_token = "ghp_secretABCD"
+        resp = client.get("/api/pr-review/config")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["token_set"] is True
+        assert body["token_hint"] == "…ABCD"
+        assert "ghp_secretABCD" not in str(body)  # raw token never returned
+
+    @patch("maggy.config.save")
+    def test_set_token(self, _save, client):
+        resp = client.post("/api/pr-review/config", json={"github_token": "ghp_botTOKEN"})
+        assert resp.status_code == 200
+        assert resp.json()["token_set"] is True
+        assert client.app.state.cfg.review.github_token == "ghp_botTOKEN"
+
+    @patch("maggy.config.save")
+    def test_clear_token_falls_back(self, _save, client, monkeypatch):
+        client.app.state.cfg.review.github_token = "ghp_old"
+        monkeypatch.setenv("GITHUB_TOKEN", "env_tok")
+        resp = client.post("/api/pr-review/config", json={"clear_token": True})
+        assert resp.json()["token_set"] is False
+        assert resp.json()["uses_env_fallback"] is True
+        assert client.app.state.cfg.review.github_token == ""
+
+    @patch("maggy.config.save")
+    def test_set_default_dry_run(self, _save, client):
+        resp = client.post("/api/pr-review/config", json={"default_dry_run": False})
+        assert resp.json()["default_dry_run"] is False
+
+
 class TestRun:
     def test_missing_token_400(self, client, monkeypatch):
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)


### PR DESCRIPTION
Adds a Reviewer Bot card to Settings + GET/POST /api/pr-review/config (token masked, never returned raw). One field to make reviews post as a bot instead of the user's env PAT. 4 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PR reviewer bot configuration in Settings, allowing users to set and manage GitHub token credentials for the PR review bot
  * Token security enhanced with masking—the raw token is never displayed in the UI
  * Added ability to toggle default dry-run mode for PR reviews
  * Users can now explicitly clear configured tokens and rely on environment fallback when needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->