### PR TITLE
release(maggy): 0.2.0 — council PR reviewer

### DIFF
--- a/maggy/maggy/__init__.py
+++ b/maggy/maggy/__init__.py
@@ -1,3 +1,3 @@
 """Maggy — generic AI engineering command center."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/maggy/maggy/main.py
+++ b/maggy/maggy/main.py
@@ -363,7 +363,7 @@ def create_app() -> FastAPI:
             f"You configured host={cfg.dashboard.host!r} — set auth_mode=\"token\" and MAGGY_API_KEY, "
             f"or bind to 127.0.0.1."
         )
-    app = FastAPI(title="Maggy", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(title="Maggy", version="0.2.0", lifespan=lifespan)
     app.add_middleware(_NoCacheStatic)
     app.state.cfg = cfg
     app.state.configured = config_mod.is_configured()

--- a/maggy/pyproject.toml
+++ b/maggy/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # Import package stays `maggy`; PyPI distribution name is `maggy-harness`
 # because `maggy` is taken on PyPI (a Hopsworks hyperparameter library).
 name = "maggy-harness"
-version = "0.1.0"
+version = "0.2.0"
 description = "Maggy — a local AI engineering command center: multi-model routing, intent graph, memory, and a web dashboard for Claude Code."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump to 0.2.0 for the agentic council PR reviewer feature. Tagging v0.2.0 after merge triggers the PyPI publish workflow.