### PR TITLE
feat(maggy): uninstall path (closes #28)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -50,6 +50,16 @@ cd "$(cat ~/.claude/.bootstrap-dir)"
 git pull && ./install.sh
 ```
 
+### Uninstall
+
+```bash
+maggy uninstall        # dry-run — preview exactly what would be removed
+maggy uninstall --yes  # remove the managed assets (your own files are spared)
+pip uninstall maggy-harness
+```
+
+Full revert guide (incl. `~/.maggy` data, `settings.json` hooks, srooter): [UNINSTALL.md](UNINSTALL.md).
+
 ---
 
 ## Path B: Maggy -- Autonomous Engineering Harness

--- a/UNINSTALL.md
+++ b/UNINSTALL.md
@@ -1,0 +1,93 @@
+# Uninstalling
+
+Reverting Claude Bootstrap / Maggy is meant to be safe and reversible. The
+installer only *adds* managed files into standard locations — it never edits
+your existing dotfiles in place (with one exception: srooter shell routing, if
+you enabled it, adds one line to your shell rc).
+
+## TL;DR
+
+```bash
+maggy uninstall          # dry-run — shows exactly what would be removed
+maggy uninstall --yes    # actually remove the managed assets
+pip uninstall maggy-harness
+```
+
+`maggy uninstall` is **dry-run by default** and only removes the asset *names*
+the installer placed — your own files in `~/.claude`, `~/bin`, and `~/.maggy`
+are left untouched.
+
+---
+
+## What `maggy uninstall` removes
+
+It mirrors the installer, removing only what it placed:
+
+| Location | What |
+|----------|------|
+| `~/.claude/skills/` | the bundled skill folders |
+| `~/.claude/commands/` | the bundled slash-command files |
+| `~/.claude/hooks/` | the bundled hook scripts |
+| `~/.claude/rules/` | the bundled rule files |
+| `~/.claude/templates/` | the bundled templates |
+| `~/bin/` | the model-delegation wrappers (`qwen3`, `deepseek`, `kimi`, …) |
+| `~/.maggy/plugins/` | the installed plugin folders |
+| `~/.claude/.bootstrap-dir` | the install marker |
+
+If you installed from a checkout that's since moved, point at it:
+`maggy uninstall --source /path/to/checkout --yes`.
+
+---
+
+## What it intentionally leaves (remove manually if you want a clean slate)
+
+These hold data or are shared with other tools, so the uninstaller won't delete
+them automatically:
+
+**1. The Python package**
+```bash
+pip uninstall maggy-harness          # or: pipx uninstall maggy-harness
+```
+
+**2. Maggy data + config** — local DBs, workspaces, settings:
+```bash
+rm -rf ~/.maggy                      # ⚠️ deletes Maggy's local data
+rm -rf ~/.config/maggy               # if present
+```
+
+**3. `~/.claude/settings.json` hook lines** — the installer doesn't own this
+file, but `/initialize-project` or srooter may have wired hooks into it. After
+removing the hook scripts, open it and delete any `hooks` entries that point at
+`~/.claude/hooks/...` paths that no longer exist, so Claude Code doesn't warn.
+
+**4. srooter shell routing** (only if you ran `srooterctl enable`):
+```bash
+srooterctl disable                   # stop routing new terminals
+# then remove this line from ~/.zshrc if present:
+#   [ -f "$HOME/.srooter/active.env" ] && . "$HOME/.srooter/active.env"  # srooter
+rm -rf ~/.srooter                    # optional: drop the saved key + state
+```
+
+**5. Other tool configs the installer may have seeded** (safe to leave):
+```bash
+rm -f  ~/.kimi/config.toml.bootstrap
+rm -f  ~/.codex/templates/AGENTS.md
+rm -rf ~/.polyphony                  # if you used Polyphony
+```
+
+---
+
+## Fully manual fallback (no `maggy` command available)
+
+If the package is already gone and you just want the files out:
+
+```bash
+# managed asset dirs under ~/.claude (these are the bundled ones)
+rm -rf ~/.claude/skills ~/.claude/rules ~/.claude/templates
+rm -f  ~/.claude/.bootstrap-dir
+# remove the bundled commands/hooks/bin wrappers by name as needed, then:
+pip uninstall maggy-harness
+```
+
+> Tip: run `maggy uninstall` (dry-run) **before** `pip uninstall` to get the
+> exact list of files for your install.

--- a/maggy/CHANGELOG.md
+++ b/maggy/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Maggy will be documented in this file.
 
 ---
 
+## [6.52.0] - 2026-06-21
+
+### Uninstall path (#28)
+
+#### Added
+- **`maggy uninstall`** — removes exactly what `maggy bootstrap` / `install.sh`
+  placed (bundled skills, commands, hooks, rules, templates, `~/bin` model
+  wrappers, plugins, and the install marker). **Dry-run by default**; `--yes` to
+  remove. It only removes asset *names* the source defines, so your own files in
+  `~/.claude`, `~/bin`, and `~/.maggy` are never touched.
+- **`UNINSTALL.md`** — a full revert guide: the one-liner, what's removed, and
+  the deliberately-left-alone bits (the pip package, `~/.maggy` data,
+  `settings.json` hook lines, srooter shell routing) with copy-paste commands.
+- 6 tests (plan is non-destructive, removal is symmetric with bootstrap, user
+  files are spared, marker removed, no-source errors clearly).
+
 ## [6.51.0] - 2026-06-20
 
 ### Agentic council PR reviewer — `maggy.review`

--- a/maggy/maggy/cli.py
+++ b/maggy/maggy/cli.py
@@ -73,6 +73,45 @@ def bootstrap(
 
 
 @app.command()
+def uninstall(
+    source: str = typer.Option(
+        None, "--source", "-s",
+        help="Path to the checkout used to install (else $MAGGY_BOOTSTRAP_DIR or marker)",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y",
+        help="Actually remove. Without this it's a dry-run preview.",
+    ),
+) -> None:
+    """Remove what `maggy bootstrap` installed (skills, hooks, commands, ~/bin wrappers, plugins)."""
+    from maggy.services.bootstrap import BootstrapError
+    from maggy.services.uninstall import plan_uninstall, run_uninstall
+    try:
+        plan = plan_uninstall(source)
+    except BootstrapError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+    if sum(len(v) for v in plan.values()) == 0:
+        console.print("[green]Nothing to remove — no bootstrap assets found.[/green]")
+        return
+    console.print("[yellow]Will remove:[/yellow]" if yes else "[yellow]Would remove (dry-run):[/yellow]")
+    for cat, names in plan.items():
+        if names:
+            extra = "…" if len(names) > 8 else ""
+            console.print(f"  {cat}: {len(names)} — {', '.join(names[:8])}{extra}")
+    if not yes:
+        console.print("\n[dim]Re-run with [bold]--yes[/bold] to remove. Left alone: the pip package, "
+                      "Maggy data (~/.maggy), and ~/.claude/settings.json — see UNINSTALL.md.[/dim]")
+        return
+    removed = run_uninstall(source)
+    n = sum(len(v) for v in removed.values())
+    console.print(f"[green]✓ Removed {n} item(s).[/green]")
+    console.print("[dim]Still installed (remove manually if you want): the package "
+                  "([bold]pip uninstall maggy-harness[/bold]), ~/.maggy data, and any hook lines in "
+                  "~/.claude/settings.json. See UNINSTALL.md.[/dim]")
+
+
+@app.command()
 def restart() -> None:
     """Stop and restart the Maggy server."""
     console.print("[dim]Stopping Maggy server…[/dim]")

--- a/maggy/maggy/services/uninstall.py
+++ b/maggy/maggy/services/uninstall.py
@@ -1,0 +1,93 @@
+"""`maggy uninstall` — remove the assets `maggy bootstrap` installed.
+
+Symmetric with bootstrap: it removes ONLY the asset names the source defines
+(the skills / commands / hooks / ~bin wrappers / plugin folders it placed), so
+it never touches the user's own files in ~/.claude, ~/bin, or ~/.maggy. The pip
+package, the Maggy config + data, and any srooter shell routing are left alone
+on purpose — see UNINSTALL.md for those manual steps.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from maggy.services.bootstrap import _plugins_src, _resolve_source
+
+
+def _asset_names(src: Path, *, dirs_only: bool = False) -> list[str]:
+    """Top-level asset names bootstrap would have placed from `src`."""
+    if not src.is_dir():
+        return []
+    names = []
+    for item in src.iterdir():
+        if item.name.startswith(".") or item.name == "__pycache__":
+            continue
+        if dirs_only and not item.is_dir():
+            continue
+        names.append(item.name)
+    return names
+
+
+def _remove(target_dir: Path, names: list[str]) -> list[str]:
+    """Remove each named entry from target_dir; return what was removed."""
+    removed = []
+    for name in names:
+        p = target_dir / name
+        if p.is_symlink() or p.is_file():
+            p.unlink()
+            removed.append(name)
+        elif p.is_dir():
+            shutil.rmtree(p)
+            removed.append(name)
+    return removed
+
+
+def _targets(claude_home, bin_dir, plugins_dir):
+    """Resolve the three install roots, defaulting to the standard locations."""
+    return (
+        claude_home or (Path.home() / ".claude"),
+        bin_dir or (Path.home() / "bin"),
+        plugins_dir or (Path.home() / ".maggy" / "plugins"),
+    )
+
+
+def _categories(src, claude_home, bin_dir, plugins_dir):
+    """category -> (target_dir, asset_names) for every managed asset class.
+
+    Covers both `maggy bootstrap` (skills/commands/hooks/bin/plugins) and the
+    extra ~/.claude assets `install.sh` places (rules/templates). Missing source
+    dirs yield no names, so a category is simply skipped when absent.
+    """
+    return {
+        "skills": (claude_home / "skills", _asset_names(src / "skills")),
+        "commands": (claude_home / "commands", _asset_names(src / "commands")),
+        "hooks": (claude_home / "hooks", _asset_names(src / "hooks")),
+        "rules": (claude_home / "rules", _asset_names(src / "rules")),
+        "templates": (claude_home / "templates", _asset_names(src / "templates")),
+        "bin": (bin_dir, _asset_names(src / "bin")),
+        "plugins": (plugins_dir, _asset_names(_plugins_src(src), dirs_only=True)),
+    }
+
+
+def plan_uninstall(source=None, *, claude_home=None, bin_dir=None, plugins_dir=None) -> dict[str, list[str]]:
+    """What uninstall WOULD remove, per category — only entries that exist."""
+    src = _resolve_source(source)
+    claude_home, bin_dir, plugins_dir = _targets(claude_home, bin_dir, plugins_dir)
+    cats = _categories(src, claude_home, bin_dir, plugins_dir)
+    return {cat: [n for n in names if (tdir / n).exists()] for cat, (tdir, names) in cats.items()}
+
+
+def run_uninstall(
+    source=None, *, claude_home=None, bin_dir=None, plugins_dir=None, remove_marker=True,
+) -> dict[str, list[str]]:
+    """Remove bootstrap-installed assets. Returns what was removed per category."""
+    src = _resolve_source(source)
+    claude_home, bin_dir, plugins_dir = _targets(claude_home, bin_dir, plugins_dir)
+    cats = _categories(src, claude_home, bin_dir, plugins_dir)
+    result = {cat: _remove(tdir, names) for cat, (tdir, names) in cats.items()}
+    marker = claude_home / ".bootstrap-dir"
+    if remove_marker and marker.exists():
+        marker.unlink()
+        result["marker"] = [".bootstrap-dir"]
+    return result

--- a/maggy/tests/test_uninstall.py
+++ b/maggy/tests/test_uninstall.py
@@ -1,0 +1,80 @@
+"""Tests for `maggy uninstall` — symmetric, non-destructive asset removal."""
+
+from __future__ import annotations
+
+import pytest
+
+from maggy.services.bootstrap import BootstrapError, run_bootstrap
+from maggy.services.uninstall import plan_uninstall, run_uninstall
+
+
+def _make_source(root):
+    """A fake bootstrap checkout: skills/ commands/ hooks/ bin/ plugins/."""
+    src = root / "src"
+    (src / "skills").mkdir(parents=True)
+    (src / "skills" / "base.md").write_text("base")
+    (src / "skills" / "python").mkdir()
+    (src / "skills" / "python" / "SKILL.md").write_text("py")
+    (src / "commands").mkdir()
+    (src / "commands" / "maggy.md").write_text("cmd")
+    (src / "hooks").mkdir()
+    (src / "hooks" / "route-task-hook").write_text("hook")
+    (src / "bin").mkdir()
+    (src / "bin" / "qwen3").write_text("#!/bin/sh\n")
+    (src / "plugins" / "build-in-public").mkdir(parents=True)
+    (src / "plugins" / "build-in-public" / "plugin.yaml").write_text("id: bip")
+    return src
+
+
+@pytest.fixture()
+def installed(tmp_path):
+    src = _make_source(tmp_path)
+    ch, bd, pd = tmp_path / "claude", tmp_path / "bin", tmp_path / "plugins"
+    run_bootstrap(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+    return src, ch, bd, pd
+
+
+class TestPlan:
+    def test_plan_lists_installed_assets(self, installed):
+        src, ch, bd, pd = installed
+        plan = plan_uninstall(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+        assert "base.md" in plan["skills"] and "python" in plan["skills"]
+        assert "qwen3" in plan["bin"]
+        assert "build-in-public" in plan["plugins"]
+
+    def test_plan_is_nondestructive(self, installed):
+        src, ch, bd, pd = installed
+        plan_uninstall(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+        assert (ch / "skills" / "base.md").exists()  # preview removed nothing
+
+
+class TestRun:
+    def test_removes_installed_assets(self, installed):
+        src, ch, bd, pd = installed
+        run_uninstall(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+        assert not (ch / "skills" / "base.md").exists()
+        assert not (ch / "skills" / "python").exists()
+        assert not (ch / "commands" / "maggy.md").exists()
+        assert not (bd / "qwen3").exists()
+        assert not (pd / "build-in-public").exists()
+
+    def test_spares_user_files(self, installed):
+        src, ch, bd, pd = installed
+        (ch / "skills" / "my-own.md").write_text("keep")  # user's own asset
+        (bd / "my-tool").write_text("keep")
+        run_uninstall(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+        assert (ch / "skills" / "my-own.md").exists()
+        assert (bd / "my-tool").exists()
+
+    def test_removes_marker(self, installed):
+        src, ch, bd, pd = installed
+        assert (ch / ".bootstrap-dir").exists()
+        run_uninstall(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+        assert not (ch / ".bootstrap-dir").exists()
+
+    def test_no_source_raises(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MAGGY_BOOTSTRAP_DIR", raising=False)
+        # point HOME at an empty dir so no marker is found
+        monkeypatch.setenv("HOME", str(tmp_path / "empty_home"))
+        with pytest.raises(BootstrapError):
+            run_uninstall(None)


### PR DESCRIPTION
Closes #28.

Adds `maggy uninstall` (dry-run by default, `--yes` to remove) — symmetric with `maggy bootstrap`, removing only the asset names the installer placed, never the user's own files. Plus `UNINSTALL.md` covering the manual bits (pip package, `~/.maggy` data, `settings.json` hooks, srooter routing). 6 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `maggy uninstall` command to remove assets installed during bootstrap; operates as a dry-run by default, with `--yes` flag to confirm removal.

* **Documentation**
  * Added comprehensive uninstall guides detailing which managed assets are removed, components left for manual cleanup, and fallback instructions for manual uninstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->