### PR TITLE
feat(maggy): backup / restore / diff — safe reversible installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [6.53.0] - 2026-06-21
+
+### Backup / restore / diff — safe, reversible installs
+
+#### Added
+- **`maggy backup` / `maggy restore` / `maggy diff`** — snapshot your existing
+  files before installing, roll back anytime, and preview exactly what a
+  bootstrap would add or change vs your current setup. `maggy bootstrap`
+  auto-backs-up first, so your pristine pre-Maggy state is always recoverable.
+  Backups (settings.json + only the files Maggy would overwrite) live in
+  `~/.maggy/backups/<timestamp>/`. See [UNINSTALL.md](UNINSTALL.md).
+
+See [maggy/CHANGELOG.md](maggy/CHANGELOG.md) for the full per-release detail.
+
 ## [6.52.0] - 2026-06-21
 
 ### Uninstall path (#28)

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -50,15 +50,19 @@ cd "$(cat ~/.claude/.bootstrap-dir)"
 git pull && ./install.sh
 ```
 
-### Uninstall
+### Preview, back up & uninstall
 
 ```bash
+maggy diff             # what would change vs your current setup
+maggy backup           # snapshot your existing files (bootstrap also auto-backs-up first)
+maggy restore          # roll back to your pre-Maggy files (--list to choose one)
+
 maggy uninstall        # dry-run — preview exactly what would be removed
 maggy uninstall --yes  # remove the managed assets (your own files are spared)
 pip uninstall maggy-harness
 ```
 
-Full revert guide (incl. `~/.maggy` data, `settings.json` hooks, srooter): [UNINSTALL.md](UNINSTALL.md).
+Full backup/restore + revert guide (incl. `~/.maggy` data, `settings.json` hooks, srooter): [UNINSTALL.md](UNINSTALL.md).
 
 ---
 

--- a/UNINSTALL.md
+++ b/UNINSTALL.md
@@ -19,6 +19,33 @@ are left untouched.
 
 ---
 
+## Backup, restore & diff (before you install)
+
+You don't have to take Maggy's word for it — preview and snapshot first:
+
+```bash
+maggy diff               # what would change vs your current setup (+new / ~changed / identical)
+maggy backup             # snapshot your existing files (settings.json + anything Maggy would overwrite)
+maggy restore --list     # list snapshots
+maggy restore            # restore the newest (or --id <stamp>)
+```
+
+`maggy bootstrap` **auto-backs-up first** — so your very first install captures
+your pristine, pre-Maggy state. To roll the machine back to exactly how it was:
+
+```bash
+maggy restore            # bring back your original files
+maggy uninstall --yes    # remove Maggy's added files
+```
+
+Backups live in `~/.maggy/backups/<timestamp>/` (a plain mirror of your home
+layout — you can also just copy files back by hand). They capture **only** your
+own pre-existing files that Maggy would overwrite, never Maggy's own assets
+(those come off with `maggy uninstall`). Skip the auto-backup with
+`maggy bootstrap --no-backup`.
+
+---
+
 ## What `maggy uninstall` removes
 
 It mirrors the installer, removing only what it placed:

--- a/maggy/CHANGELOG.md
+++ b/maggy/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Maggy will be documented in this file.
 
 ---
 
+## [6.53.0] - 2026-06-21
+
+### Backup / restore / diff — safe, reversible installs
+
+#### Added
+- **`maggy backup`** — snapshots your *existing* files before Maggy touches
+  them: `~/.claude/settings.json` plus any pre-existing file an install would
+  overwrite (a *collision*). Stored in `~/.maggy/backups/<timestamp>/` as a plain
+  mirror of your home layout, with a manifest.
+- **`maggy restore`** (`--list`, `--id`) — restores a snapshot (newest by
+  default), bringing your original files back.
+- **`maggy diff`** — overview of what a bootstrap would do vs your current setup,
+  per asset: **+new / ~changed / identical**. See before you install.
+- **Auto-backup on `maggy bootstrap`** — it snapshots first (so the very first
+  install captures pristine, pre-Maggy state), `--no-backup` to skip.
+- Captures **only** your own files (never Maggy's assets — those revert via
+  `maggy uninstall`). 7 tests. `UNINSTALL.md` + GETTING_STARTED updated.
+
 ## [6.52.0] - 2026-06-21
 
 ### Uninstall path (#28)

--- a/maggy/maggy/cli.py
+++ b/maggy/maggy/cli.py
@@ -58,10 +58,20 @@ def bootstrap(
         None, "--source", "-s",
         help="Path to a claude-bootstrap checkout (else $MAGGY_BOOTSTRAP_DIR or marker)",
     ),
+    no_backup: bool = typer.Option(
+        False, "--no-backup", help="Skip the automatic pre-install backup of your existing files",
+    ),
 ) -> None:
     """Install Maggy's skills, hooks, commands, ~/bin model wrappers, and plugins."""
     from maggy.services.bootstrap import BootstrapError, run_bootstrap
+    from maggy.services.snapshot import create_backup
     try:
+        if not no_backup:
+            m = create_backup(source)
+            n = sum(len(v) for v in m["captured"].values())
+            if n:
+                console.print(f"[dim]Backed up {n} existing file(s) → {m['id']} "
+                              f"([bold]maggy restore[/bold] to roll back)[/dim]")
         result = run_bootstrap(source)
     except BootstrapError as e:
         console.print(f"[red]{e}[/red]")
@@ -70,6 +80,74 @@ def bootstrap(
     for asset, n in result.items():
         console.print(f"  {asset}: {n}")
     console.print("\n[dim]Run [bold]maggy serve[/bold] to start the dashboard.[/dim]")
+
+
+@app.command()
+def backup(
+    source: str = typer.Option(None, "--source", "-s", help="Install source (else marker/env)"),
+) -> None:
+    """Snapshot your existing files (settings.json + anything Maggy would overwrite)."""
+    from maggy.services.bootstrap import BootstrapError
+    from maggy.services.snapshot import create_backup
+    try:
+        m = create_backup(source)
+    except BootstrapError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+    n = sum(len(v) for v in m["captured"].values())
+    console.print(f"[green]✓ Backup {m['id']}[/green] — captured {n} file(s).")
+    for cat, names in m["captured"].items():
+        console.print(f"  {cat}: {', '.join(names)}")
+    if not n:
+        console.print("[dim]Nothing to back up — no existing files would be overwritten.[/dim]")
+
+
+@app.command()
+def restore(
+    backup_id: str = typer.Option(None, "--id", help="Backup id to restore (default: newest)"),
+    show_list: bool = typer.Option(False, "--list", "-l", help="List available backups"),
+) -> None:
+    """Restore your files from a backup (newest by default)."""
+    from maggy.services.snapshot import list_backups, restore_backup
+    backups = list_backups()
+    if show_list or not backups:
+        if not backups:
+            console.print("[yellow]No backups found.[/yellow]")
+            return
+        console.print("[bold]Backups (newest first):[/bold]")
+        for b in backups:
+            n = sum(len(v) for v in b["captured"].values())
+            console.print(f"  {b['id']} — {n} file(s)")
+        return
+    out = restore_backup(backup_id)
+    console.print(f"[green]✓ Restored backup {out['id']}[/green] — {out['restored']} file(s).")
+
+
+@app.command()
+def diff(
+    source: str = typer.Option(None, "--source", "-s", help="Install source (else marker/env)"),
+) -> None:
+    """Overview of what a bootstrap would change vs your current setup."""
+    from maggy.services.bootstrap import BootstrapError
+    from maggy.services.snapshot import diff_install
+    try:
+        d = diff_install(source)
+    except BootstrapError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+    add = sum(len(v["add"]) for v in d.values())
+    chg = sum(len(v["change"]) for v in d.values())
+    same = sum(len(v["same"]) for v in d.values())
+    console.print(f"[bold]vs your setup:[/bold] [green]+{add} new[/green], "
+                  f"[yellow]~{chg} changed[/yellow], [dim]{same} identical[/dim]")
+    for cat, b in d.items():
+        if b["add"] or b["change"]:
+            parts = []
+            if b["add"]:
+                parts.append(f"[green]+{len(b['add'])}[/green]")
+            if b["change"]:
+                parts.append(f"[yellow]~{', '.join(b['change'][:6])}[/yellow]")
+            console.print(f"  {cat}: {'  '.join(parts)}")
 
 
 @app.command()

--- a/maggy/maggy/services/snapshot.py
+++ b/maggy/maggy/services/snapshot.py
@@ -1,0 +1,161 @@
+"""Backup / restore / diff for the install footprint.
+
+Before Maggy overwrites anything, it can snapshot the user's *existing* files so
+the original state is recoverable. A backup captures:
+  - `~/.claude/settings.json` (the highest-value user file), and
+  - every pre-existing file Maggy would overwrite (a *collision* — a file the
+    user already had at a managed asset path).
+
+Maggy's own new files aren't captured (they restore via `maggy uninstall`). The
+snapshot mirrors the home layout under `~/.maggy/backups/<id>/`, so restore is a
+plain merge-copy back. `diff_install` shows what an install would add/change.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+from maggy.services.bootstrap import _plugins_src, _resolve_source
+from maggy.services.uninstall import _categories, _targets
+
+# managed category -> where it lives under a backup dir (mirrors $HOME layout)
+_REL = {
+    "skills": "claude/skills", "commands": "claude/commands", "hooks": "claude/hooks",
+    "rules": "claude/rules", "templates": "claude/templates",
+    "bin": "bin", "plugins": "maggy/plugins",
+}
+
+
+def _backups_dir(backups_dir: Path | None) -> Path:
+    return backups_dir or (Path.home() / ".maggy" / "backups")
+
+
+def _now_id() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _stash(src_path: Path, dest_path: Path) -> None:
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    if src_path.is_dir():
+        shutil.copytree(src_path, dest_path, dirs_exist_ok=True)
+    else:
+        shutil.copy2(src_path, dest_path)
+
+
+def collisions(source=None, *, claude_home=None, bin_dir=None, plugins_dir=None) -> dict[str, list[str]]:
+    """User's pre-existing files that an install would overwrite, per category."""
+    src = _resolve_source(source)
+    claude_home, bin_dir, plugins_dir = _targets(claude_home, bin_dir, plugins_dir)
+    cats = _categories(src, claude_home, bin_dir, plugins_dir)
+    return {cat: [n for n in names if (tdir / n).exists()] for cat, (tdir, names) in cats.items()}
+
+
+def create_backup(
+    source=None, *, claude_home=None, bin_dir=None, plugins_dir=None,
+    backups_dir=None, backup_id=None,
+) -> dict:
+    """Snapshot settings.json + collisions into ~/.maggy/backups/<id>/."""
+    src = _resolve_source(source)
+    claude_home, bin_dir, plugins_dir = _targets(claude_home, bin_dir, plugins_dir)
+    dest = _backups_dir(backups_dir) / (backup_id or _now_id())
+    captured: dict[str, list[str]] = {}
+
+    settings = claude_home / "settings.json"
+    if settings.exists():
+        _stash(settings, dest / "claude" / "settings.json")
+        captured["settings"] = ["settings.json"]
+
+    for cat, (tdir, names) in _categories(src, claude_home, bin_dir, plugins_dir).items():
+        hit = [n for n in names if (tdir / n).exists()]
+        for n in hit:
+            _stash(tdir / n, dest / _REL[cat] / n)
+        if hit:
+            captured[cat] = hit
+
+    manifest = {"id": dest.name, "source": str(src), "captured": captured}
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
+def list_backups(backups_dir=None) -> list[dict]:
+    """Manifests of all backups, newest first."""
+    bdir = _backups_dir(backups_dir)
+    if not bdir.is_dir():
+        return []
+    out = []
+    for d in sorted((p for p in bdir.iterdir() if p.is_dir()), reverse=True):
+        m = d / "manifest.json"
+        if m.exists():
+            out.append(json.loads(m.read_text()))
+    return out
+
+
+def _merge_copy(snap_dir: Path, target_dir: Path) -> int:
+    """Copy every file under snap_dir back into target_dir (overwriting)."""
+    if not snap_dir.is_dir():
+        return 0
+    n = 0
+    for item in snap_dir.rglob("*"):
+        if item.is_file():
+            dst = target_dir / item.relative_to(snap_dir)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(item, dst)
+            n += 1
+    return n
+
+
+def restore_backup(
+    backup_id=None, *, claude_home=None, bin_dir=None, plugins_dir=None, backups_dir=None,
+) -> dict:
+    """Restore a backup (latest if id omitted). Returns files restored."""
+    backups = list_backups(backups_dir)
+    if not backups:
+        raise FileNotFoundError("no backups found")
+    chosen = backup_id or backups[0]["id"]
+    dest = _backups_dir(backups_dir) / chosen
+    if not (dest / "manifest.json").exists():
+        raise FileNotFoundError(f"backup not found: {chosen}")
+    claude_home, bin_dir, plugins_dir = _targets(claude_home, bin_dir, plugins_dir)
+    restored = (
+        _merge_copy(dest / "claude", claude_home)
+        + _merge_copy(dest / "bin", bin_dir)
+        + _merge_copy(dest / "maggy" / "plugins", plugins_dir)
+    )
+    return {"id": chosen, "restored": restored}
+
+
+def _entries_equal(a: Path, b: Path) -> bool:
+    """Deep content compare of two files or two directories (skips __pycache__)."""
+    if a.is_dir() and b.is_dir():
+        af = {p.relative_to(a): p for p in a.rglob("*") if p.is_file() and "__pycache__" not in p.parts}
+        bf = {p.relative_to(b): p for p in b.rglob("*") if p.is_file() and "__pycache__" not in p.parts}
+        return set(af) == set(bf) and all(af[k].read_bytes() == bf[k].read_bytes() for k in af)
+    return a.is_file() and b.is_file() and a.read_bytes() == b.read_bytes()
+
+
+def _classify(src_entry: Path, tgt_entry: Path) -> str:
+    if not tgt_entry.exists():
+        return "add"
+    return "same" if _entries_equal(src_entry, tgt_entry) else "change"
+
+
+def diff_install(source=None, *, claude_home=None, bin_dir=None, plugins_dir=None) -> dict:
+    """What `maggy bootstrap` would do per asset: add (new) / change (overwrite) / same."""
+    src = _resolve_source(source)
+    claude_home, bin_dir, plugins_dir = _targets(claude_home, bin_dir, plugins_dir)
+    src_dirs = {
+        "skills": src / "skills", "commands": src / "commands", "hooks": src / "hooks",
+        "rules": src / "rules", "templates": src / "templates",
+        "bin": src / "bin", "plugins": _plugins_src(src),
+    }
+    out: dict[str, dict[str, list[str]]] = {}
+    for cat, (tdir, names) in _categories(src, claude_home, bin_dir, plugins_dir).items():
+        buckets: dict[str, list[str]] = {"add": [], "change": [], "same": []}
+        for n in names:
+            buckets[_classify(src_dirs[cat] / n, tdir / n)].append(n)
+        out[cat] = buckets
+    return out

--- a/maggy/tests/test_snapshot.py
+++ b/maggy/tests/test_snapshot.py
@@ -1,0 +1,106 @@
+"""Tests for backup / restore / diff of the install footprint."""
+
+from __future__ import annotations
+
+import pytest
+
+from maggy.services.snapshot import (
+    collisions,
+    create_backup,
+    diff_install,
+    list_backups,
+    restore_backup,
+)
+
+
+def _make_source(root):
+    """A fake bootstrap checkout."""
+    src = root / "src"
+    (src / "skills").mkdir(parents=True)
+    (src / "skills" / "base.md").write_text("MAGGY base v2")
+    (src / "commands").mkdir()
+    (src / "commands" / "maggy.md").write_text("MAGGY cmd")
+    (src / "hooks").mkdir()
+    (src / "hooks" / "route-task-hook").write_text("MAGGY hook")
+    (src / "bin").mkdir()
+    (src / "bin" / "qwen3").write_text("MAGGY qwen")
+    (src / "plugins" / "bip").mkdir(parents=True)
+    (src / "plugins" / "bip" / "plugin.yaml").write_text("id: bip")
+    return src
+
+
+@pytest.fixture()
+def homes(tmp_path):
+    src = _make_source(tmp_path)
+    ch, bd, pd, bk = (tmp_path / "claude", tmp_path / "bin",
+                      tmp_path / "plugins", tmp_path / "backups")
+    ch.mkdir()
+    return src, ch, bd, pd, bk
+
+
+class TestCollisions:
+    def test_only_preexisting_are_collisions(self, homes):
+        src, ch, bd, pd, _ = homes
+        (ch / "skills").mkdir()
+        (ch / "skills" / "base.md").write_text("MY OWN base")  # collides
+        col = collisions(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+        assert col["skills"] == ["base.md"]
+        assert col["bin"] == []  # qwen3 not installed yet -> no collision
+
+
+class TestBackupRestore:
+    def test_backup_captures_settings_and_collisions(self, homes):
+        src, ch, bd, pd, bk = homes
+        (ch / "settings.json").write_text('{"mine": true}')
+        (ch / "skills").mkdir()
+        (ch / "skills" / "base.md").write_text("MY OWN base")
+        m = create_backup(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd,
+                          backups_dir=bk, backup_id="b1")
+        assert m["captured"]["settings"] == ["settings.json"]
+        assert m["captured"]["skills"] == ["base.md"]
+        assert (bk / "b1" / "claude" / "settings.json").exists()
+
+    def test_restore_brings_back_original(self, homes):
+        src, ch, bd, pd, bk = homes
+        (ch / "settings.json").write_text('{"mine": true}')
+        create_backup(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd,
+                      backups_dir=bk, backup_id="b1")
+        (ch / "settings.json").write_text('{"clobbered": true}')  # something changed it
+        out = restore_backup("b1", claude_home=ch, bin_dir=bd, plugins_dir=pd, backups_dir=bk)
+        assert out["restored"] >= 1
+        assert (ch / "settings.json").read_text() == '{"mine": true}'
+
+    def test_restore_latest_when_no_id(self, homes):
+        src, ch, bd, pd, bk = homes
+        (ch / "settings.json").write_text("v1")
+        create_backup(str(src), claude_home=ch, backups_dir=bk, backup_id="20260101-000000")
+        (ch / "settings.json").write_text("v2")
+        create_backup(str(src), claude_home=ch, backups_dir=bk, backup_id="20260201-000000")
+        (ch / "settings.json").write_text("v3")
+        restore_backup(None, claude_home=ch, bin_dir=bd, plugins_dir=pd, backups_dir=bk)
+        assert (ch / "settings.json").read_text() == "v2"  # newest backup
+
+    def test_list_backups_newest_first(self, homes):
+        src, ch, bd, pd, bk = homes
+        create_backup(str(src), claude_home=ch, backups_dir=bk, backup_id="20260101-000000")
+        create_backup(str(src), claude_home=ch, backups_dir=bk, backup_id="20260301-000000")
+        ids = [b["id"] for b in list_backups(bk)]
+        assert ids == ["20260301-000000", "20260101-000000"]
+
+    def test_restore_missing_raises(self, homes):
+        src, ch, bd, pd, bk = homes
+        with pytest.raises(FileNotFoundError):
+            restore_backup("nope", claude_home=ch, backups_dir=bk)
+
+
+class TestDiff:
+    def test_add_change_same(self, homes):
+        src, ch, bd, pd, _ = homes
+        (ch / "skills").mkdir()
+        (ch / "skills" / "base.md").write_text("MAGGY base v2")  # identical -> same
+        (ch / "commands").mkdir()
+        (ch / "commands" / "maggy.md").write_text("OLD version")  # differs -> change
+        d = diff_install(str(src), claude_home=ch, bin_dir=bd, plugins_dir=pd)
+        assert d["skills"]["same"] == ["base.md"]
+        assert d["commands"]["change"] == ["maggy.md"]
+        assert "qwen3" in d["bin"]["add"]  # not installed -> would be added


### PR DESCRIPTION
Adds `maggy backup` / `maggy restore` / `maggy diff`, and auto-backup before `maggy bootstrap`. Snapshots only the user's own files an install would overwrite (settings.json + collisions) to `~/.maggy/backups/<ts>/`; restore + uninstall = full roll back. 7 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)