### PR TITLE
docs: map changelog to PyPI 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [6.53.0] - 2026-06-21
 
+> Published to PyPI as **`maggy-harness` 0.2.1** (together with 6.52.0). The
+> changelog tracks feature versions; the PyPI package uses semver from 0.1.0.
+
 ### Backup / restore / diff — safe, reversible installs
 
 #### Added

--- a/maggy/CHANGELOG.md
+++ b/maggy/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Maggy will be documented in this file.
 
 ## [6.53.0] - 2026-06-21
 
+> Published to PyPI as **`maggy-harness` 0.2.1** (together with 6.52.0). The
+> changelog tracks feature versions; the PyPI package uses semver from 0.1.0.
+
 ### Backup / restore / diff — safe, reversible installs
 
 #### Added


### PR DESCRIPTION
Adds a PyPI-version note to the 6.53.0 entries so users can map features to the pip release.