### PR TITLE
feat(maggy/review): diff compressor for the council panel

### DIFF
--- a/maggy/CHANGELOG.md
+++ b/maggy/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to Maggy will be documented in this file.
 
 ---
 
-## [6.54.0] - 2026-06-22
+## [6.55.0] - 2026-06-22
+
+### Council reviewer — diff compressor (token savings)
+
+#### Added
+- **`maggy/review/output_filter.py`** — compresses the per-file diff slices the
+  council reviewer re-sends to its 2–5 model panel: collapses runs of unchanged
+  context lines (`… N hidden …`) and stubs generated/lockfiles. **Hard invariant:
+  a changed line (`+`/`-`) or hunk header is never dropped** — proven by a
+  property test — and the full patch stays one `get_diff(path)` tool call away.
+  ~98% smaller on a lockfile-heavy chunk, multiplied across the panel; 0% / lossless
+  on tight diffs. (The build-not-buy outcome of a 4-model council review of RTK:
+  format-specific Python, no Rust binary in the wheel, no global-hook risk.) 11 tests.
 
 ### Parallel chats per project — worktree-isolated
 

--- a/maggy/maggy/review/output_filter.py
+++ b/maggy/maggy/review/output_filter.py
@@ -1,0 +1,63 @@
+"""Targeted output filtering for the council reviewer — strip low-signal bytes
+before a per-file diff slice is re-sent to a 2–5 model panel (the ×panel
+multiplier is where the real token waste is).
+
+The hard invariant: **a changed line (`+`/`-`) or a hunk header (`@@`) is NEVER
+dropped.** Only runs of *unchanged context lines* far from a change collapse to a
+marker, and known generated/lockfiles are stubbed. The full patch is always one
+`get_diff(path)` tool call away, so this is lossless for the reviewer's purpose.
+This is the build-not-buy answer to RTK: format-specific, unit-testable, no
+third-party binary in the command path.
+"""
+
+from __future__ import annotations
+
+# Lockfiles / generated artifacts: noise to a *semantic* reviewer; the static
+# gate covers their correctness. Diff body is stubbed, not sent.
+_GENERATED_NAMES = (
+    "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock",
+    "cargo.lock", "go.sum", "composer.lock", "gemfile.lock", "uv.lock",
+)
+_GENERATED_MARKERS = (
+    "/dist/", "/build/", "/.next/", "/node_modules/", "/vendor/",
+    ".min.js", ".min.css", ".map", ".snap",
+)
+
+
+def is_generated(path: str) -> bool:
+    """True for lockfiles / build output / snapshots — diff body is low-signal."""
+    p = path.lower()
+    if any(p.endswith(name) for name in _GENERATED_NAMES):
+        return True
+    return any(marker in p for marker in _GENERATED_MARKERS)
+
+
+def compress_patch(patch: str, context: int = 3) -> str:
+    """Collapse runs of unchanged context lines, keeping `context` around each
+    change. Every non-context line (``@@``/``+``/``-``/``\\``) is preserved."""
+    lines = patch.splitlines()
+    n = len(lines)
+    if n == 0:
+        return patch
+    # A context line is one starting with a single space; everything else is an
+    # anchor (hunk header, added, removed, no-newline marker) and is always kept.
+    keep = [not ln.startswith(" ") for ln in lines]
+    for i in range(n):
+        if not lines[i].startswith(" "):
+            for j in range(max(0, i - context), min(n, i + context + 1)):
+                if lines[j].startswith(" "):
+                    keep[j] = True
+    out: list[str] = []
+    i = 0
+    while i < n:
+        if keep[i]:
+            out.append(lines[i])
+            i += 1
+            continue
+        j = i
+        while j < n and not keep[j]:
+            j += 1
+        hidden = j - i
+        out.append(f"… {hidden} unchanged line{'s' if hidden != 1 else ''} hidden …")
+        i = j
+    return "\n".join(out)

--- a/maggy/maggy/review/pipeline.py
+++ b/maggy/maggy/review/pipeline.py
@@ -22,6 +22,7 @@ from .config import CHAIR, PRICING_KEY, available, cost_usd, load_env, load_skil
 from .github import get_pr, get_pr_files, post_review
 from .languages import detect_languages
 from .models import ReviewChunk, Verdict
+from .output_filter import compress_patch, is_generated
 from .static_check import run_static_gate
 
 # tool-using review agents make many requests (read_file/grep loops); the default
@@ -119,13 +120,24 @@ def decompose(files, langs) -> list[ReviewChunk]:
 
 def chunk_diff_text(files, chunk_files, per_file=PER_FILE_DIFF_CHARS, cap=MAX_CHUNK_DIFF_CHARS):
     """Diff text for ONLY this chunk's files — so a reviewer never judges on a
-    truncated global diff (the bug that produced false positives on mega PRs)."""
+    truncated global diff (the bug that produced false positives on mega PRs).
+
+    Per-file patches are compressed (far context collapsed, no changed line ever
+    dropped) and generated/lockfiles are stubbed — this slice is re-sent to every
+    panel reviewer, so trimming low-signal bytes here multiplies by panel size.
+    The full patch is always reachable via the reviewer's get_diff(path) tool.
+    """
     want = set(chunk_files)
     parts = []
     for f in files:
-        if f["filename"] in want and f.get("patch"):
-            parts.append(f"--- {f['filename']} (+{f.get('additions', 0)}/-{f.get('deletions', 0)}) ---\n"
-                         f"{f['patch'][:per_file]}")
+        fn = f["filename"]
+        if fn not in want or not f.get("patch"):
+            continue
+        head = f"--- {fn} (+{f.get('additions', 0)}/-{f.get('deletions', 0)}) ---"
+        if is_generated(fn):
+            parts.append(f"{head}\n[generated/lockfile — diff omitted; static gate covers it. get_diff('{fn}') for full]")
+            continue
+        parts.append(f"{head}\n{compress_patch(f['patch'])[:per_file]}")
     return "\n\n".join(parts)[:cap]
 
 
@@ -151,7 +163,9 @@ async def review_one(name, factory, skill, focus, title, deps, on_log, usages, m
         + ("Focus: " + focus if focus else "Review the whole change.")
     )
     if diff_text:
-        prompt += f"\n\n--- DIFF (this review area) ---\n{diff_text}"
+        prompt += ("\n\n(Unchanged context lines may be collapsed as '… N hidden …'; "
+                   "every +/- changed line is shown. Call get_diff(path) for a file's full patch.)"
+                   f"\n--- DIFF (this review area) ---\n{diff_text}")
     try:
         res = await _run_agent(rv, prompt, deps, REVIEWER_LIMITS)
         _rec(usages, model_key, res)

--- a/maggy/tests/test_review_output_filter.py
+++ b/maggy/tests/test_review_output_filter.py
@@ -1,0 +1,80 @@
+"""Tests for the council reviewer's diff compressor — invariant: no changed line dropped."""
+
+from __future__ import annotations
+
+from maggy.review.output_filter import compress_patch, is_generated
+
+# A patch with lots of context around a small change.
+PATCH = "\n".join([
+    "@@ -1,12 +1,12 @@",
+    " ctx 1", " ctx 2", " ctx 3", " ctx 4", " ctx 5", " ctx 6",
+    "-old line", "+new line",
+    " ctx 7", " ctx 8", " ctx 9", " ctx 10", " ctx 11", " ctx 12",
+])
+
+
+class TestCompressPatch:
+    def test_keeps_every_changed_line(self):
+        out = compress_patch(PATCH, context=2)
+        assert "-old line" in out
+        assert "+new line" in out
+
+    def test_keeps_hunk_header(self):
+        assert "@@ -1,12 +1,12 @@" in compress_patch(PATCH, context=2)
+
+    def test_collapses_far_context(self):
+        out = compress_patch(PATCH, context=2)
+        assert "hidden" in out                 # a run of context was collapsed
+        assert out.count("ctx") < PATCH.count("ctx")  # fewer context lines
+
+    def test_keeps_context_near_changes(self):
+        out = compress_patch(PATCH, context=2)
+        # the 2 context lines on each side of the change survive
+        assert "ctx 6" in out and "ctx 7" in out
+
+    def test_invariant_no_change_line_ever_dropped(self):
+        # property check: every +/-/@@ line in any patch survives compression
+        big = "@@ -1,40 +1,40 @@\n" + "\n".join(
+            ([" same"] * 8 + ["-rm", "+add"]) * 4)
+        out = compress_patch(big, context=1)
+        for ln in big.splitlines():
+            if ln.startswith(("+", "-", "@@")):
+                assert ln in out
+
+    def test_short_patch_unchanged(self):
+        small = "@@ -1,2 +1,2 @@\n ctx\n-a\n+b\n ctx2"
+        assert compress_patch(small, context=3) == small  # nothing to collapse
+
+    def test_empty(self):
+        assert compress_patch("") == ""
+
+
+class TestIsGenerated:
+    def test_lockfiles(self):
+        assert is_generated("frontend/package-lock.json")
+        assert is_generated("Cargo.lock")
+        assert is_generated("backend/poetry.lock")
+
+    def test_build_output(self):
+        assert is_generated("apps/web/dist/bundle.js")
+        assert is_generated("x.min.js")
+        assert is_generated("comp/__snapshots__/a.snap")
+
+    def test_real_source_is_not_generated(self):
+        assert not is_generated("src/api/routes.py")
+        assert not is_generated("lib/auth.ts")
+
+
+class TestChunkDiffIntegration:
+    def test_chunk_diff_compresses_and_stubs(self):
+        import pytest
+        pytest.importorskip("pydantic_ai")
+        from maggy.review.pipeline import chunk_diff_text
+        files = [
+            {"filename": "src/a.py", "patch": PATCH, "additions": 1, "deletions": 1},
+            {"filename": "package-lock.json", "patch": "@@ -1 +1 @@\n-x\n+y", "additions": 1, "deletions": 1},
+        ]
+        out = chunk_diff_text(files, ["src/a.py", "package-lock.json"])
+        assert "-old line" in out and "+new line" in out   # changed lines preserved
+        assert "hidden" in out                              # context compressed
+        assert "diff omitted" in out                        # lockfile stubbed


### PR DESCRIPTION
Build-not-buy result of the RTK council review: a format-specific diff compressor (collapse context, stub lockfiles) with a 'no changed line ever dropped' invariant + get_diff escape hatch. ~98% smaller on lockfile-heavy chunks × panel size. 11 tests.