### PR TITLE
fix(maggy): protocol matcher hijacks compound requests

### DIFF
--- a/maggy/maggy/skills/intent_matcher.py
+++ b/maggy/maggy/skills/intent_matcher.py
@@ -1,7 +1,26 @@
-"""Match user messages to protocol triggers."""
+"""Match user messages to protocol triggers.
+
+A protocol (run-tests, git-push, create-pr…) is a fast-path shortcut that
+short-circuits the agent and just runs canned steps. So it must only fire on a
+*bare invocation* ("run tests", "push to github"), never on a compound build
+request that merely mentions a trigger as one clause — e.g. "implement it, test
+it, then merge it" must reach the agent (which implements AND tests), not run
+the test protocol alone.
+"""
 from __future__ import annotations
 
+import re
+
 from maggy.skills.protocol_models import Protocol
+
+# Verbs/connectors that mean "do real work" or "then do another thing" — their
+# presence (OUTSIDE the matched trigger) marks an agent task, not a bare
+# protocol invocation. We check this on the message with the trigger removed, so
+# a trigger that legitimately contains "create" (create-pr) isn't self-vetoed.
+_BUILD_INTENT = re.compile(
+    r"\b(implement|build|creat\w*|add|write|fix|refactor|design|develop|"
+    r"generate|merge|then|after that|also)\b",
+)
 
 
 def match_protocol(
@@ -11,11 +30,19 @@ def match_protocol(
         return None
     lower = message.lower()
     best: Protocol | None = None
-    best_len = 0
+    best_trigger = ""
     for proto in protocols:
         for trigger in proto.triggers:
             tl = trigger.lower()
-            if tl in lower and len(tl) > best_len:
+            if tl in lower and len(tl) > len(best_trigger):
                 best = proto
-                best_len = len(tl)
+                best_trigger = tl
+    if best is None:
+        return None
+    # Veto when the request carries build/multi-step intent BEYOND the trigger
+    # itself — then it's an agent task ("implement it, test it, then merge it"),
+    # and the agent runs the tests as part of doing the work.
+    remainder = lower.replace(best_trigger, " ", 1)
+    if _BUILD_INTENT.search(remainder):
+        return None
     return best

--- a/maggy/tests/test_intent_matcher.py
+++ b/maggy/tests/test_intent_matcher.py
@@ -62,3 +62,30 @@ class TestMatchProtocol:
         p = match_protocol("push to github please", protocols)
         assert p is not None
         assert p.name == "git-push"
+
+
+class TestCompoundRequestNotHijacked:
+    """A protocol must NOT hijack a request that also asks to build/implement —
+    otherwise 'implement it, test it, then merge it' runs only the tests."""
+
+    def test_implement_test_merge_not_hijacked(self, protocols):
+        p = match_protocol("can u implement it, test it and then merge it", protocols)
+        assert p is None  # this is an agent task, not a bare test run
+
+    def test_build_and_push_not_hijacked(self, protocols):
+        p = match_protocol("build the feature and push changes", protocols)
+        assert p is None
+
+    def test_add_feature_then_test_not_hijacked(self, protocols):
+        p = match_protocol("add a new endpoint and test it", protocols)
+        assert p is None
+
+    def test_fix_then_create_pr_not_hijacked(self, protocols):
+        p = match_protocol("fix the bug then create a pr", protocols)
+        assert p is None
+
+    def test_bare_invocation_still_matches(self, protocols):
+        # the fast-path must still work for genuine bare invocations
+        assert match_protocol("run tests", protocols).name == "run-tests"
+        assert match_protocol("push to github", protocols).name == "git-push"
+        assert match_protocol("can you run the tests please", protocols).name == "run-tests"


### PR DESCRIPTION
Bare substring matching hijacked 'implement it, test it, then merge it' → ran only tests. Now strips the trigger first, vets the remainder for build intent. 5 new tests.