### PR TITLE
feat: non-negotiable Definition of Done rules

### DIFF
--- a/skills/base/SKILL.md
+++ b/skills/base/SKILL.md
@@ -214,12 +214,20 @@ How to verify this is complete:
 │     └─ Run full test suite with coverage                    │
 │     └─ Verify coverage threshold (≥80%)                     │
 ├─────────────────────────────────────────────────────────────┤
-│  4. COMPLETE: Mark Done                                     │
+│  4. PROVE + COMPLETE: Show evidence, then mark done         │
 │     └─ Only after ALL validations pass                      │
-│     └─ Move todo to completed.md                            │
-│     └─ Checkpoint session state                             │
+│     └─ SHOW PROOF — paste the real test/lint/type output    │
+│        (pass/fail counts), never just "tests pass"          │
+│     └─ UI change? attach a screenshot / visual-diff         │
+│     └─ Generated content? show the actual artifact          │
+│     └─ Move todo to completed.md + checkpoint session state │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+> **Done = proven, not claimed.** A todo is only complete when the evidence is in
+> your response: real command output, a screenshot for any UI change, the actual
+> artifact for any generated content. No proof → not done. (See the
+> "Definition of Done — NON-NEGOTIABLE" section in CLAUDE.md.)
 
 #### Execution Commands by Stack
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -20,6 +20,31 @@ You are a brilliant engineer who also happens to be genuinely funny. Think dry w
 @.claude/skills/cross-agent-delegation/SKILL.md
 @.claude/skills/polyphony/SKILL.md
 
+## Definition of Done — NON-NEGOTIABLE
+
+A task is **not done until you have proven it works.** "It should work", "the code
+looks correct", or "tests pass" without evidence is **not done**. Every task ends
+with proof pasted into your response. No proof → not done, no exceptions.
+
+1. **Tests are specified clearly, up front.** Before implementing, state the exact
+   test(s) that will validate the task and what pass looks like (TDD: write them
+   first, watch them fail). A task with no named test is not ready to start.
+2. **Results are shown as proof — never claimed.** Paste the *actual* command
+   output: the real test run (pass/fail counts), lint, type-check, build. A summary
+   like "all tests pass" without the output is a claim, not proof.
+3. **Frontend / UI change → ALWAYS a screenshot.** If the change is visible in a UI,
+   capture and show a screenshot (or a visual-regression golden/diff) of the real
+   rendered result. Describing the UI is not proof — the pixels are. No screenshot →
+   the UI task is not done.
+4. **Content generation → ALWAYS show the artifact.** If the task produces content
+   (docs, copy, a generated file/asset, an email, a report), show the *actual*
+   generated output, not a description of it.
+5. **If you could not verify, say so explicitly.** Never imply done when a step was
+   skipped. "Tests written but not run because X" is honest; silence that lets the
+   user assume success is not. Report failures and skips plainly, with the output.
+
+When in doubt, over-show the evidence. Skipping proof is the fastest way to ship a bug.
+
 ## Project Context
 - Language: [e.g., TypeScript]
 - Framework: [e.g., Next.js 14 (App Router)]


### PR DESCRIPTION
Adds proof-of-done rules to the installed CLAUDE.md template + base skill TDD workflow: tests specified clearly, results as proof, UI→screenshot, content→artifact. 'Done = proven, not claimed.'