### PR TITLE
feat: flex provider routing with data sovereignty (rebased #26)

### DIFF
--- a/bin/groq
+++ b/bin/groq
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Groq CLI — calls Groq API (OpenAI-compatible) with Llama models.
+
+Usage:
+  groq "prompt"                    # default model (llama-3.3-70b-versatile)
+  groq --model llama-3.1-70b-versatile "prompt"
+  echo "prompt" | groq             # stdin mode
+  cat file.txt | groq              # pipe mode
+"""
+
+import os
+import sys
+
+import httpx
+
+API_KEY = os.environ.get("GROQ_API_KEY", "")
+BASE_URL = "https://api.groq.com/openai/v1"
+DEFAULT_MODEL = os.environ.get("GROQ_MODEL", "llama-3.3-70b-versatile")
+
+
+def main():
+    model = DEFAULT_MODEL
+    prompt = None
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--model" and i + 1 < len(args):
+            i += 1
+            model = args[i]
+        elif not args[i].startswith("-"):
+            prompt = args[i]
+        i += 1
+
+    if not API_KEY:
+        print("[groq] ERROR: GROQ_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+
+    if not prompt and not sys.stdin.isatty():
+        prompt = sys.stdin.read().strip()
+
+    if not prompt:
+        print("Usage: groq [--model <model>] <prompt>", file=sys.stderr)
+        sys.exit(1)
+
+    print(call_groq(prompt, model))
+
+
+def call_groq(prompt: str, model: str) -> str:
+    try:
+        with httpx.Client(timeout=300) as client:
+            resp = client.post(
+                f"{BASE_URL}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "max_tokens": 16000,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data["choices"][0]["message"]["content"]
+    except httpx.HTTPError as e:
+        return f"[Groq API error: {e}]"
+    except Exception as e:
+        return f"[Groq error: {e}]"
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/ollama-coder
+++ b/bin/ollama-coder
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Ollama Coder CLI — calls local Ollama instance with a coding model.
+
+Usage:
+  ollama-coder "prompt"                          # default model
+  ollama-coder --model codellama:34b "prompt"
+  echo "prompt" | ollama-coder                   # stdin mode
+  cat file.txt | ollama-coder                    # pipe mode
+
+Env vars:
+  OLLAMA_BASE           Ollama base URL (default: http://localhost:11434)
+  OLLAMA_CODER_MODEL    Model to use (default: qwen2.5-coder:72b)
+"""
+
+import os
+import sys
+
+import httpx
+
+BASE_URL = os.environ.get("OLLAMA_BASE", "http://localhost:11434")
+DEFAULT_MODEL = os.environ.get("OLLAMA_CODER_MODEL", "qwen2.5-coder:72b")
+
+
+def main():
+    model = DEFAULT_MODEL
+    prompt = None
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--model" and i + 1 < len(args):
+            i += 1
+            model = args[i]
+        elif not args[i].startswith("-"):
+            prompt = args[i]
+        i += 1
+
+    if not prompt and not sys.stdin.isatty():
+        prompt = sys.stdin.read().strip()
+
+    if not prompt:
+        print("Usage: ollama-coder [--model <model>] <prompt>", file=sys.stderr)
+        sys.exit(1)
+
+    result = call_ollama(prompt, model)
+    if result is None:
+        print("[ollama-coder] ERROR: Ollama not reachable at " + BASE_URL, file=sys.stderr)
+        sys.exit(1)
+    print(result)
+
+
+def call_ollama(prompt: str, model: str) -> str | None:
+    try:
+        with httpx.Client(timeout=300) as client:
+            resp = client.post(
+                f"{BASE_URL}/api/chat",
+                json={
+                    "model": model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                    "options": {"temperature": 0.1},
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("message", {}).get("content", "[no content]")
+    except httpx.ConnectError:
+        return None
+    except httpx.HTTPError as e:
+        return f"[Ollama API error: {e}]"
+    except Exception as e:
+        return f"[Ollama error: {e}]"
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/together
+++ b/bin/together
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Together AI CLI — calls Together AI API (OpenAI-compatible).
+
+Usage:
+  together "prompt"                              # default (405B)
+  together --model meta-llama/Llama-3.3-70B-Instruct-Turbo "prompt"
+  echo "prompt" | together                       # stdin mode
+  cat file.txt | together                        # pipe mode
+"""
+
+import os
+import sys
+
+import httpx
+
+API_KEY = os.environ.get("TOGETHER_API_KEY", "")
+BASE_URL = "https://api.together.xyz/v1"
+DEFAULT_MODEL = os.environ.get(
+    "TOGETHER_MODEL",
+    "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+)
+
+
+def main():
+    model = DEFAULT_MODEL
+    prompt = None
+
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--model" and i + 1 < len(args):
+            i += 1
+            model = args[i]
+        elif not args[i].startswith("-"):
+            prompt = args[i]
+        i += 1
+
+    if not API_KEY:
+        print("[together] ERROR: TOGETHER_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+
+    if not prompt and not sys.stdin.isatty():
+        prompt = sys.stdin.read().strip()
+
+    if not prompt:
+        print("Usage: together [--model <model>] <prompt>", file=sys.stderr)
+        sys.exit(1)
+
+    print(call_together(prompt, model))
+
+
+def call_together(prompt: str, model: str) -> str:
+    try:
+        with httpx.Client(timeout=300) as client:
+            resp = client.post(
+                f"{BASE_URL}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "max_tokens": 16000,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data["choices"][0]["message"]["content"]
+    except httpx.HTTPError as e:
+        return f"[Together API error: {e}]"
+    except Exception as e:
+        return f"[Together error: {e}]"
+
+
+if __name__ == "__main__":
+    main()

--- a/blog-data-sovereignty.md
+++ b/blog-data-sovereignty.md
@@ -1,0 +1,262 @@
+# Your Code Is the New Factory Floor — Don't Outsource It to China
+
+*A technical and cultural case for AI data sovereignty in the era of LLM-powered development*
+
+---
+
+There is a sentence that every American software engineer should read slowly before running their next AI coding assistant:
+
+**"Your source code, your business logic, your API keys, your architecture decisions — where do they go when you hit Enter?"**
+
+If you are using DeepSeek as your coding AI, the answer is: **China.**
+
+Not metaphorically. Not as hyperbole. Literally — to servers in Hangzhou, operated by a company called High-Flyer, a Chinese quantitative hedge fund, under Chinese law, which includes the National Intelligence Law of 2017. That law requires Chinese organizations to "support, assist, and cooperate with state intelligence work" when asked.
+
+We are not here to demonize DeepSeek. Their engineering is genuinely world-class. The V3 model is one of the most impressive open-weights releases in AI history. The team is brilliant, the benchmarks are real, and the price point is extraordinary.
+
+But brilliant engineering from a Chinese company does not change the legal architecture it operates under.
+
+And we have been here before.
+
+---
+
+## We Watched the Factory Leave. Are We About to Watch the Data Leave Too?
+
+In the 1970s and 1980s, American politicians and business leaders made a generational bet: manufacturing was a commodity. Ship it to China. Keep the "high value" work — design, brand, finance — at home.
+
+For a generation it looked like genius. Cheap goods. Fat margins. Globalization as inevitability.
+
+We now know what that bet actually cost. Entire industrial regions hollowed out. Supply chains weaponized during a pandemic. Semiconductor dependencies exposed. A geopolitical rival with industrial capacity that took sixty years and trillions of dollars to build — handed to them in the name of quarterly earnings.
+
+The AI era is offering us the exact same trade, dressed in new clothes.
+
+The offer this time is not "let us make your widgets cheaply." It is "let us process your intelligence cheaply." Your code. Your business logic. Your unreleased product architecture. Your security models. Your customer data patterns. Every prompt you send to a Chinese AI API is a packet of intelligence leaving your country.
+
+The politicians of the 70s and 80s were not stupid. They were optimistic. They believed economic interdependence would moderate behavior. They were wrong.
+
+We should not repeat the same mistake in software.
+
+---
+
+## Enter Maggy — An Autonomous AI Engineering Command Center
+
+Before we talk about what we built, credit where it is due.
+
+**[Maggy](https://github.com/alinaqi/maggy)** — built by Ali Naqi — is one of the most thoughtful open-source AI engineering systems available today. It is not a wrapper around a single model. It is a full orchestration layer: a 10-tier intelligent routing system that classifies every task by complexity and cost, then delegates to the cheapest model capable of handling it.
+
+The architecture is genuinely sophisticated:
+
+- A **FastAPI backend** with 30+ route modules covering chat, memory, competitor intelligence, deployment, and more
+- **Mnemos** — a typed memory graph that survives context compaction, with a 4-dimension fatigue model that detects agent struggle before it becomes a death spiral
+- **62 pre-built skills** covering TDD enforcement, security review, agent teams, multi-database patterns, and more
+- A **plugin system** where new capabilities drop in as folders — no core changes needed
+- A **hook system** that intercepts every Claude Code prompt before Claude sees it and routes it to the right model
+
+The routing logic alone is worth studying. Rather than a single point of failure, it cascades:
+
+```
+Your prompt
+    ↓
+qwen3 (local, free) classifies complexity
+    ↓ fails? →
+kimi fallback
+    ↓ fails? →
+flash model fallback
+    ↓ always available →
+Claude handles it directly
+```
+
+The result: **~80% of coding tasks never reach Claude.** Simple code, boilerplate, CRUD, tests — handled by cheaper models. Claude is reserved for architecture, security, and quality-critical work. A developer paying $5-15/day on Claude alone can get to $0.50-1.50 with intelligent routing.
+
+This is not a toy. This is a production-grade engineering system.
+
+And it shipped with DeepSeek as the workhorse for that 80%.
+
+---
+
+## The Problem We Had to Fix
+
+The default configuration of Maggy routes the bulk of coding tasks — everything from "write this CRUD endpoint" to "refactor this module" — through DeepSeek's API.
+
+That means your code goes to China.
+
+Not your final built artifact. Not a compiled binary. Your **source code**. The raw, readable, proprietary logic of what you are building. The architecture of systems that have not shipped yet. The names of your internal services. The patterns in your data models. The security assumptions baked into your auth layer.
+
+For a hobbyist building a weekend project, maybe that is an acceptable trade. For a company building software that matters — healthcare, fintech, defense-adjacent, any regulated industry — it is not.
+
+And for engineers who simply believe that the AI era should not repeat the manufacturing outsourcing mistake, it is a principle worth acting on.
+
+So we forked Maggy, studied the architecture, appreciated the elegance of what was built, and added **data sovereignty as a first-class feature**.
+
+The PR is here: **[sseshachala:feat/flex-provider-routing-sovereignty → alinaqi/maggy #26](https://github.com/alinaqi/maggy/pull/26)**
+
+---
+
+## What We Built: Flex Provider Routing With Sovereignty Enforcement
+
+The core idea is simple: **the routing logic is brilliant and should be preserved. Only the destination needs to change.**
+
+DeepSeek's tier position in Maggy — cheap flash tier, capable pro tier — can be filled by US-based or local models with comparable performance. The orchestration, the hook system, the memory layer, the skills — all of that stays intact. We just swap who gets the prompt.
+
+### The Config Layer
+
+A single file — `~/.maggy/routing.yaml` — controls everything:
+
+```yaml
+# Data sovereignty mode
+sovereignty: us       # us | local | any
+
+# Provider per tier
+tiers:
+  flash: groq         # simple code, boilerplate, tests
+  pro: together       # multi-file features, refactors, debugging
+```
+
+Three sovereignty modes:
+
+| Mode | What it means |
+|------|--------------|
+| `us` | US-based providers only. Blocks DeepSeek, Kimi, Moonshot. Uses Groq + Together AI. |
+| `local` | Nothing leaves your machine. Ollama only. Air-gapped. |
+| `any` | No restrictions. User's choice. DeepSeek remains available. |
+
+The enforcement happens at **two layers** — both the Python config module and the bash hook that intercepts Claude Code prompts. You cannot accidentally route to a blocked provider. It falls back automatically.
+
+### The US Stack
+
+**Flash tier → [Groq](https://groq.com)**
+- US company. Llama 3.3 70B.
+- ~$0.05/M tokens — actually *cheaper* than DeepSeek Flash ($0.14/M).
+- Fastest inference available anywhere. US data centers.
+
+**Pro tier → [Together AI](https://together.ai)**
+- US company. Llama 3.1 405B.
+- ~$3.50/M tokens. Near Claude Sonnet quality for most coding tasks.
+- US data centers.
+
+**Local tier → [Ollama](https://ollama.com)**
+- No API. Runs on your machine.
+- `qwen2.5-coder:72b` — excellent coding model, ironically from Alibaba but run locally means zero data egress.
+- Free. Private. Air-gapped.
+
+### The European and Asian Option
+
+For teams in Europe (GDPR constraints) or Asia (local compliance requirements), the `local` sovereignty mode with Ollama is the clean answer — no data leaves the machine, period. Alternatively, the config accepts any OpenAI-compatible endpoint, so teams can point the flash and pro tiers at:
+
+- **EU:** Mistral API (French company, EU data residency), OVHcloud-hosted models
+- **Asia:** Any regional provider running OpenAI-compatible endpoints — NIM on local infrastructure, private Together AI deployments, or simply Ollama with models pulled locally
+
+The routing logic and hook system are provider-agnostic. The bin scripts (`bin/groq`, `bin/together`, `bin/ollama-coder`) follow a simple contract: accept a prompt, write a response to stdout. Adding a new regional provider is 30 lines of Python and one entry in `routing.yaml`.
+
+### What Did Not Change
+
+Everything that makes Maggy powerful:
+
+- The 10-tier routing intelligence
+- Mnemos memory system
+- TDD enforcement via Stop hooks
+- The 62 skills
+- The plugin system
+- The dashboard
+- The competitor intelligence
+- Claude at Tier 11 for architecture and security
+
+The routing *destination* changed. The routing *intelligence* did not.
+
+---
+
+## The Cost Picture
+
+Here is what the swap looks like financially:
+
+| Setup | Daily cost (est. ~1M tokens) |
+|-------|------------------------------|
+| All Claude | $5–15 |
+| Maggy with DeepSeek (original) | $0.50–1.50 |
+| Maggy with Groq + Together AI (this PR) | $0.50–2.00 |
+| Maggy with Ollama only | $0 |
+
+The US-stack costs roughly the same as DeepSeek at the flash tier (Groq is actually cheaper) and modestly more at the pro tier (Together AI 405B vs DeepSeek Pro). The quality at the pro tier is comparable — Llama 3.1 405B is a serious model.
+
+The delta is small. The principle is not.
+
+---
+
+## A Note on Appreciating What DeepSeek Built
+
+Let us be direct: DeepSeek built something extraordinary. The V3 model punches above its weight class on almost every benchmark. The team released weights openly when they could have kept them proprietary. The price-performance ratio disrupted the market in ways that benefited everyone — it forced every major API provider to cut prices.
+
+Americans are good at this: recognizing excellence wherever it comes from. We imported German engineering talent after World War II. We built the internet on protocols designed collaboratively across borders. We hired the best minds from every country and built great things together.
+
+That tradition is worth preserving.
+
+But appreciating technical excellence is not the same as being naive about the geopolitical context it operates in. Chinese engineers built DeepSeek. The Chinese state operates the legal environment DeepSeek must comply with. Those are two separate facts, and conflating them — either to dismiss the engineering or to ignore the legal reality — does a disservice to both.
+
+The manufacturing outsourcing of the 1970s and 1980s was not driven by malice. It was driven by optimism, short-termism, and a failure to think in generational terms about what was actually being traded away.
+
+We are in the early days of a technology that will restructure how intelligence is produced, distributed, and controlled. The data patterns of how software is built — what gets built, by whom, for what purpose, with what security assumptions — are themselves strategically valuable. Routing that data through infrastructure subject to Chinese state intelligence requirements is a choice. A choice that compounds quietly, at scale, over years.
+
+We would rather not make that choice.
+
+---
+
+## How to Use This
+
+**If you are already using Maggy:**
+
+```bash
+# 1. Pull the branch or wait for the PR to merge
+git clone https://github.com/alinaqi/maggy.git
+
+# 2. Copy the config template
+cp templates/routing.yaml ~/.maggy/routing.yaml
+
+# 3. Set your API keys
+export GROQ_API_KEY="gsk_..."         # from console.groq.com
+export TOGETHER_API_KEY="..."          # from api.together.xyz
+
+# 4. For fully local (no keys needed):
+#    Set sovereignty: local in routing.yaml
+#    ollama pull qwen2.5-coder:72b
+
+# 5. Run Maggy as normal
+cd maggy && maggy serve
+```
+
+**Sovereignty presets in `~/.maggy/routing.yaml`:**
+
+```yaml
+# Full US stack
+sovereignty: us
+tiers: { flash: groq, pro: together }
+
+# Fully local / air-gapped
+sovereignty: local
+tiers: { flash: ollama, pro: ollama }
+
+# No restrictions (DeepSeek available)
+sovereignty: any
+tiers: { flash: groq, pro: deepseek }
+```
+
+The dashboard at `localhost:8080` exposes `GET/POST /api/routing/provider-config` so you can inspect and update your sovereignty settings without editing YAML.
+
+---
+
+## The PR
+
+Everything described here is open and reviewable:
+
+- **Original project:** https://github.com/alinaqi/maggy
+- **Our fork:** https://github.com/sseshachala/maggy
+- **Pull request:** https://github.com/alinaqi/maggy/pull/26
+
+The implementation is 51 tests, 11 files, one clean commit. The routing intelligence is untouched. The sovereignty enforcement is additive.
+
+If you are building software that matters, route it accordingly.
+
+---
+
+*Built with [Maggy](https://github.com/alinaqi/maggy) — we appreciate what Ali Naqi and the team built. This is a contribution in that spirit.*
+
+*Questions, improvements, or regional provider additions welcome via PR.*

--- a/comparision.md
+++ b/comparision.md
@@ -287,3 +287,98 @@ Based on published pricing (approximate):
 The biggest saving is already baked into the routing design (not using Claude for everything). Swapping DeepSeek for Groq/Ollama is a smaller delta — but removes the China data concern entirely.
 
 > **Note:** Groq pricing changes frequently. Verify at groq.com/pricing before implementing.
+
+---
+
+## Is US-based cheaper AND better than DeepSeek?
+
+For the **flash tier** (simple code, boilerplate) — yes, Groq is cheaper AND faster than DeepSeek Flash. No quality trade-off.
+
+For the **pro tier** (features, refactors, debugging):
+
+| | DeepSeek Pro | Groq Llama 3.3 70B | Ollama local |
+|---|---|---|---|
+| Cost | $0.44/$0.87/M | ~$0.59/$0.79/M | $0 |
+| Code quality | Very strong | Good, not quite as sharp | Depends on hardware |
+| Speed | Fast | Fastest inference available | Depends on GPU/CPU |
+| Privacy | China servers | US servers | Your machine |
+
+- Flash tier → Groq (cheaper + faster, no quality loss)
+- Pro tier → Ollama locally if you have a good GPU (free + private), or Together AI 405B for quality
+- The real win is **data sovereignty** — code never leaves US infrastructure or your machine
+
+---
+
+## Flex config — let users choose their provider per tier
+
+Design: a config file (`~/.maggy/routing.yaml`) where each tier maps to the user's preferred provider:
+
+```yaml
+# ~/.maggy/routing.yaml
+tiers:
+  flash: groq           # groq | deepseek | ollama
+  pro: ollama-coder     # ollama-coder | deepseek | together | groq
+  multimodal: gemini    # stays as-is
+```
+
+**What needs to be built:**
+1. `bin/groq` — Groq API script (Llama 3.3 70B)
+2. `bin/ollama-coder` — Ollama script (qwen2.5-coder:72b)
+3. `bin/together` — Together AI script (Llama 3.1 405B)
+4. `~/.maggy/routing.yaml` — user config with defaults
+5. `model_router.py` — reads config, swaps provider at startup
+6. `route-task-hook` — reads config, picks the right `bin/` script per tier
+7. REST endpoint `GET/POST /api/routing/config` — dashboard can read/update without editing YAML
+
+**Result:** US-only users set `flash: groq, pro: together`. Fully local users set both to `ollama`. DeepSeek stays available as an option, just not the default.
+
+**Effort: ~4-5 hours.**
+
+**Recommended defaults:** Groq for flash, Together AI for pro.
+
+---
+
+## Is Ollama quality the same as Claude?
+
+No. Honest quality ladder for coding:
+
+```
+Claude Opus
+    ↓ (small gap)
+Claude Sonnet
+    ↓ (small-medium gap)
+Together AI 405B / DeepSeek Pro
+    ↓ (medium gap)
+Groq Llama 3.3 70B
+    ↓ (medium gap)
+Ollama qwen2.5-coder:72b (good hardware)
+    ↓ (big gap)
+Ollama on CPU / smaller models
+```
+
+**Ollama local (qwen2.5-coder:72b):**
+- Strong at straightforward tasks — CRUD, tests, boilerplate, single-file changes
+- Struggles with complex multi-file refactors, subtle bugs, ambiguous requirements
+- Quality depends heavily on your GPU RAM
+- 72B on CPU is slow and noticeably weaker than API models
+
+**Together AI (Llama 3.1 405B):**
+- Much closer to Claude Sonnet for coding — 405B parameters makes a real difference
+- Good at multi-file work, debugging, documentation
+- Still behind Claude on architecture reasoning and security analysis
+
+**Conclusion:** Ollama is great for flash-tier tasks. For pro-tier work, Together AI 405B is the better US-based choice. Free does not mean equivalent.
+
+---
+
+## Claude vs Together AI pricing
+
+| Model | Input/M | Output/M |
+|-------|---------|---------|
+| Together AI Llama 3.1 405B | ~$3.50 | ~$3.50 |
+| Claude Sonnet | ~$3.00 | ~$15.00 |
+| Claude Opus | ~$15.00 | ~$75.00 |
+
+Output tokens are where Claude gets expensive — code generation produces a lot of output, that's where the bill hits. Together AI 405B is cheaper than Claude Sonnet on output (~$3.50 vs ~$15.00) and comparable quality for most coding tasks.
+
+Claude stays at Tier 11 for architecture, security, and quality-critical work where the premium is justified.

--- a/comparision.md
+++ b/comparision.md
@@ -1,0 +1,289 @@
+# Maggy — Conversation Log
+
+## What does this folder do?
+
+**Maggy** is an autonomous AI engineering command center. Here's the gist:
+
+**What it does:**
+- Routes tasks across 10+ AI models (Claude, DeepSeek, Gemini, Qwen, Grok, etc.) based on complexity and cost
+- Exposes a **FastAPI backend** with 30+ route modules — chat, plugins, budget tracking, competitor intel, deployment, testing
+- Has a **memory system** (`mnemos/`) for fatigue tracking and checkpoint serialization
+- Provides a **plugin manager** with a HookBus for extensibility
+- Ships a **vanilla JS dashboard** (`static/`) for monitoring and control
+- Includes 62+ pre-built **skills** and delegation binaries in `bin/`
+
+**Tech stack:** Python 3.11+, FastAPI, Anthropic SDK, Pydantic, Tailwind CSS (frontend)
+
+**In one sentence:** It's a meta-AI orchestration platform that wraps and routes between multiple LLMs for different task tiers, with memory, plugins, and a web dashboard.
+
+---
+
+## How could anyone use it?
+
+There are two main ways to use it:
+
+### As a Bootstrap for Any Project
+Installs skills, hooks, rules, and memory into any existing or new codebase:
+```bash
+git clone https://github.com/alinaqi/maggy.git
+cd maggy && ./install.sh
+
+# In your project
+claude
+> /initialize-project
+```
+This gives your Claude Code sessions: TDD enforcement, 62 skills, quality gates, agent teams (spec → test → implement → review → PR), and persistent memory.
+
+### As a Running AI Command Center
+Run the Maggy server to get a full dashboard + CLI:
+```bash
+cd maggy && pip install -e .
+maggy serve     # dashboard at localhost:8080
+maggy           # interactive CLI REPL
+```
+From there you get:
+- **Chat** with model routing (tasks auto-routed to cheapest capable model)
+- **Task inbox** from GitHub Issues or Asana, AI-prioritized
+- **Competitor tracking** with daily briefings
+- **Build-in-public plugin** — auto-writes LinkedIn/X posts when you ship
+
+### Who it's for
+Primarily for **solo AI-heavy developers** or small teams who want to orchestrate multiple LLMs cost-efficiently without manually picking models for every task. DeepSeek handles ~80% of work cheaply; Claude only gets called for architecture/security decisions.
+
+---
+
+## Do we need API keys for DeepSeek?
+
+Yes — each model needs its own API key set as an environment variable:
+
+| Model | Env Var | Where to get it |
+|-------|---------|-----------------|
+| DeepSeek | `DEEPSEEK_API_KEY` | platform.deepseek.com |
+| Gemini | `GEMINI_API_KEY` | aistudio.google.com |
+| Grok | `GROK_API_KEY` | console.x.ai |
+| Kimi | `KIMI_API_KEY` | platform.moonshot.cn |
+| Anthropic/Claude | `ANTHROPIC_API_KEY` | console.anthropic.com |
+| Qwen3 (local) | none — runs locally via Ollama | free |
+
+You'd set these in your shell profile (`~/.zshrc`) or a `.env` file:
+```bash
+export DEEPSEEK_API_KEY="sk-..."
+export GEMINI_API_KEY="AIza..."
+```
+
+You don't need all of them — just the models you actually want to use. DeepSeek alone covers ~80% of coding tasks per the routing design.
+
+---
+
+## DeepSeek is from China, right?
+
+Yes, DeepSeek is a Chinese AI company (based in Hangzhou, founded by High-Flyer, a Chinese hedge fund).
+
+Key concerns people raise:
+- **Data privacy** — API calls go to servers in China, subject to Chinese law
+- **Model weights** — open-source, so you can run locally and avoid the API entirely
+- **Export controls** — some orgs have policies against using Chinese AI services
+
+If that's a concern, the routing tiers in Maggy can be adjusted to skip DeepSeek and use alternatives like Gemini Pro or Claude Sonnet instead — the routing config is all in `maggy/maggy/process/model_router.py`.
+
+---
+
+## How can we build on top of what is in Maggy?
+
+Four clean extension points, from easiest to most involved:
+
+### 1. Write a Skill (easiest)
+A skill is just a Markdown + YAML file. Drop it in `skills/your-skill/` and reference it in `CLAUDE.md` via `@include`. No code needed — it's a prompt template that activates for specific tasks.
+
+Good for: adding domain knowledge, coding patterns, or workflows Claude should follow.
+
+### 2. Write a Plugin
+The most powerful extension point. Drop a folder with `plugin.yaml` + `plugin.py` into `maggy/maggy/plugins/` — auto-discovered on startup.
+
+```yaml
+id: my-plugin
+version: 1
+entrypoint: plugin.py
+hooks:
+  - event: on_task_fetch
+    handler: handle_tasks
+  - event: on_feature_shipped
+    handler: post_update
+heartbeat:
+  - name: my_poll
+    interval_seconds: 300
+    fn: poll_something
+```
+
+Good for: integrating new data sources (Linear, Jira, Notion), new output channels (Slack, Discord), or custom automation triggers.
+
+Existing plugin examples to copy: `provider-github`, `provider-asana`, `provider-monday`.
+
+### 3. Add a Model Tier / Swap DeepSeek
+Edit `maggy/maggy/process/model_router.py` and add/replace a tier. Also add a corresponding delegation script in `bin/`. The contract is simple: script accepts a prompt, writes response to stdout.
+
+Good for: replacing DeepSeek with a non-Chinese alternative (e.g. Mistral, Llama via Groq), or adding a new specialized model.
+
+### 4. Add a REST API Route
+Add a `routes_*.py` file in `maggy/maggy/api/` and register it in `maggy/maggy/main.py`. The FastAPI structure is already in place.
+
+Good for: exposing Maggy capabilities to other tools, building a frontend on top, or integrating with webhooks.
+
+---
+
+## What is the effort for #3 and #4?
+
+### #3 — Add/Swap a Model Tier
+**Effort: 1-2 hours**
+
+Two files to touch:
+
+**`maggy/maggy/process/model_router.py`** — add a new `ModelTier` to `DEFAULT_TIERS`:
+```python
+ModelTier(
+    name="mistral",
+    provider="mistral",
+    model="mistral-large-2",
+    cost_rank=4,          # sits between deepseek-flash and deepseek-pro
+    complexity_min=2,
+    complexity_max=7,
+    strengths=["code_generation", "debugging", "european_hosting"],
+),
+```
+
+**`bin/mistral`** — new delegation script (copy `bin/deepseek`, swap the API base URL and key env var). Contract is just: accept prompt → print response to stdout.
+
+To remove DeepSeek entirely: delete its two `ModelTier` entries from `DEFAULT_TIERS` and remove `bin/deepseek`.
+
+### #4 — Add a REST API Route
+**Effort: 30 minutes**
+
+1. Create `maggy/maggy/api/routes_yourfeature.py`:
+```python
+from fastapi import APIRouter, Request
+from .auth import check_auth
+
+router = APIRouter(prefix="/api/yourfeature", tags=["yourfeature"])
+
+@router.get("/something")
+async def get_something(request: Request) -> dict:
+    check_auth(request, None)
+    return {"result": "..."}
+```
+
+2. Register in `maggy/maggy/main.py` — find the block where all `routes_*.py` routers are imported and add yours alongside them.
+
+3. Write the test first (`tests/test_routes_yourfeature.py`) per the TDD policy.
+
+---
+
+## Can DeepSeek do what Claude can do?
+
+Not quite. Here's the honest comparison:
+
+**DeepSeek is good at:**
+- Code generation, refactoring, debugging
+- Writing tests, CRUD, boilerplate
+- Following instructions precisely
+- ~80% of day-to-day engineering tasks
+
+**DeepSeek falls short vs Claude on:**
+- **Security-critical reasoning** — Claude is more careful about subtle vulnerabilities
+- **Architecture decisions** — Claude reasons better about long-term trade-offs
+- **Ambiguous requirements** — Claude handles underspecified problems more gracefully
+- **Long multi-file refactors** — Claude maintains coherence better across large contexts
+- **Nuanced code review** — catches more subtle logic bugs
+
+That's exactly why Maggy's routing keeps Claude at Tier 11 (the top) — it's the model you call when correctness and judgment matter, not just code output. DeepSeek is the workhorse for volume; Claude is the senior engineer you pull in for the hard stuff.
+
+In practice: if you removed DeepSeek and routed everything to Claude, you'd get better quality but 10-20x higher cost. The routing system exists precisely to avoid that.
+
+---
+
+## Instead of DeepSeek, can we use a US/local alternative?
+
+Yes, several good options depending on whether you want **local** or **US cloud**:
+
+### Local (free, private, no API keys)
+Already have Ollama running for Qwen3 — just pull more models:
+
+| Replaces | Model | Notes |
+|----------|-------|-------|
+| DeepSeek Flash | `ollama pull codellama:34b` or `llama3.3:70b` | fast, good at code |
+| DeepSeek Pro | `ollama pull qwen2.5-coder:72b` | best local coding model right now |
+
+Zero cost, nothing leaves your machine.
+
+### US Cloud (API, cheap)
+| Replaces | Provider | Model | Cost |
+|----------|----------|-------|------|
+| DeepSeek Flash | **Groq** | `llama-3.3-70b` | ~$0.06/M — extremely fast |
+| DeepSeek Pro | **Together AI** | `llama-3.1-405b` | ~$0.35/M |
+| Both | **Fireworks AI** | various Llama/Qwen | similar pricing |
+
+Groq is the standout — US company, insanely fast inference, Llama models, very cheap.
+
+### Recommendation
+**Best swap:**
+- Flash tier → **Groq + Llama 3.3 70B** (faster than DeepSeek, US-based, cheap)
+- Pro tier → **Qwen2.5-Coder 72B via Ollama** (free, local, strong at code)
+
+The `bin/deepseek` script would need two replacements — `bin/groq-flash` and the Ollama call is already handled by the existing `bin/qwen3` pattern.
+
+---
+
+## How does it work once installed in Claude Code?
+
+```
+You type a prompt in Claude Code
+        ↓
+route-task-hook fires BEFORE Claude sees it
+        ↓
+qwen3 (local, free) classifies the task
+        ↓
+Hook injects routing instructions into Claude's context
+        ↓
+Claude reads the instruction and delegates:
+  "write this CRUD endpoint" → calls ~/bin/groq-flash
+  "refactor this module"     → calls ~/bin/ollama-pro
+  "design this auth system"  → handles it directly (CLAUDE tier)
+```
+
+**So Claude Code stays as the orchestrator** — it reads your prompt, sees the routing decision, then calls the cheaper model via the `bin/` script and returns the result. You still type in Claude Code as normal, but most of the actual generation happens in Ollama or Groq.
+
+**What we'd need to implement for your setup:**
+1. Replace `bin/deepseek` with `bin/groq` (US cloud, cheap)
+2. Add `bin/ollama-coder` pointing at `qwen2.5-coder:72b` locally
+3. Update `DEFAULT_TIERS` in `model_router.py` — swap DeepSeek entries for Groq/Ollama
+4. Update the tier names in `route-task-hook` classifier prompt
+
+**Realistic effort: 2-3 hours.**
+
+---
+
+## What is the cost difference?
+
+Based on published pricing (approximate):
+
+| Task | Current (DeepSeek) | Groq (Llama 3.3 70B) | Ollama (local) |
+|------|--------------------|----------------------|----------------|
+| Flash tier | $0.14/$0.28 per M tokens | ~$0.05/$0.08 per M | $0 |
+| Pro tier | $0.44/$0.87 per M tokens | ~$0.59/$0.79 per M | $0 |
+
+**So:**
+- **Flash tier** — Groq is actually **cheaper** than DeepSeek (~3x less)
+- **Pro tier** — Groq is roughly **similar** to DeepSeek, maybe slightly more
+- **Ollama** — free for both, just your hardware running it
+
+**Real-world estimate** for a typical dev day (~1M tokens):
+
+| Setup | Daily cost |
+|-------|-----------|
+| All Claude | ~$5-15 |
+| Current Maggy (with DeepSeek) | ~$0.50-1.50 |
+| Maggy with Groq + Ollama | ~$0.10-0.50 |
+| Maggy with pure Ollama | ~$0 |
+
+The biggest saving is already baked into the routing design (not using Claude for everything). Swapping DeepSeek for Groq/Ollama is a smaller delta — but removes the China data concern entirely.
+
+> **Note:** Groq pricing changes frequently. Verify at groq.com/pricing before implementing.

--- a/hooks/route-task-hook
+++ b/hooks/route-task-hook
@@ -2,7 +2,10 @@
 # UserPromptSubmit hook — classifies each prompt via qwen3 and
 # injects routing instructions into Claude's context.
 #
-# 6-tier routing: QWEN → DS_FLASH → DS_PRO → KIMI → CODEX → CLAUDE
+# Routing: QWEN → FLASH_TIER → PRO_TIER → KIMI → CODEX → CLAUDE
+# Flash/Pro providers are resolved from ~/.maggy/routing.yaml
+# Sovereignty modes: us (default) | local | any
+#
 # Exit 0 + additionalContext: Claude sees the routing tier.
 # Falls back to cached tier when Ollama is unreachable (post-compact safety).
 # No set -euo pipefail: hook scripts must be defensive, not strict.
@@ -10,6 +13,85 @@
 INPUT=$(cat 2>/dev/null || true)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty' 2>/dev/null || echo "")
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo ".")
+
+# ── Load provider config from ~/.maggy/routing.yaml ─────────────────────────
+ROUTING_CFG="$HOME/.maggy/routing.yaml"
+SOVEREIGNTY="us"
+FLASH_PROVIDER="groq"
+PRO_PROVIDER="together"
+
+if [ -f "$ROUTING_CFG" ]; then
+  _yaml_val() { grep -m1 "^[[:space:]]*${1}:" "$ROUTING_CFG" 2>/dev/null | awk -F': ' '{print $2}' | tr -d ' \r\n' || true; }
+  _SOVER=$(_yaml_val "sovereignty")
+  _FLASH=$(_yaml_val "flash")
+  _PRO=$(_yaml_val "pro")
+  [ -n "$_SOVER" ] && SOVEREIGNTY="$_SOVER"
+  [ -n "$_FLASH" ] && FLASH_PROVIDER="$_FLASH"
+  [ -n "$_PRO" ]   && PRO_PROVIDER="$_PRO"
+fi
+
+# Sovereignty enforcement — override provider if blocked
+_BLOCKED_US="deepseek kimi moonshot"
+_BLOCKED_LOCAL="deepseek kimi moonshot groq together openai google anthropic"
+
+_is_blocked() {
+  local provider="$1"
+  case "$SOVEREIGNTY" in
+    us)    echo "$_BLOCKED_US" | grep -qw "$provider" && return 0 ;;
+    local) echo "$_BLOCKED_LOCAL" | grep -qw "$provider" && return 0 ;;
+  esac
+  return 1
+}
+
+if _is_blocked "$FLASH_PROVIDER"; then
+  FLASH_PROVIDER="ollama"
+fi
+if _is_blocked "$PRO_PROVIDER"; then
+  PRO_PROVIDER=$( [ "$SOVEREIGNTY" = "local" ] && echo "ollama" || echo "groq" )
+fi
+
+# Resolve bin paths
+_flash_bin() {
+  case "$FLASH_PROVIDER" in
+    groq)     echo "$HOME/bin/groq" ;;
+    together) echo "$HOME/bin/together" ;;
+    ollama)   echo "$HOME/bin/ollama-coder" ;;
+    deepseek) echo "$HOME/bin/deepseek --flash" ;;
+    *)        echo "$HOME/bin/groq" ;;
+  esac
+}
+_pro_bin() {
+  case "$PRO_PROVIDER" in
+    together) echo "$HOME/bin/together" ;;
+    groq)     echo "$HOME/bin/groq" ;;
+    ollama)   echo "$HOME/bin/ollama-coder" ;;
+    deepseek) echo "$HOME/bin/deepseek --pro" ;;
+    *)        echo "$HOME/bin/together" ;;
+  esac
+}
+
+FLASH_BIN=$(_flash_bin)
+PRO_BIN=$(_pro_bin)
+
+# Cost labels for context messages
+_flash_cost() {
+  case "$FLASH_PROVIDER" in
+    groq)     echo "\$0.05/M" ;;
+    together) echo "\$3.50/M" ;;
+    ollama)   echo "free/local" ;;
+    deepseek) echo "\$0.14/M" ;;
+    *)        echo "" ;;
+  esac
+}
+_pro_cost() {
+  case "$PRO_PROVIDER" in
+    together) echo "\$3.50/M" ;;
+    groq)     echo "\$0.59/M" ;;
+    ollama)   echo "free/local" ;;
+    deepseek) echo "\$0.44/M" ;;
+    *)        echo "" ;;
+  esac
+}
 
 CACHE_FILE="$HOME/.claude/routing-cache.json"
 LOG_FILE="$HOME/.claude/routing-log.jsonl"
@@ -84,12 +166,12 @@ if [ -z "$TIER" ] && [ -x "$HOME/bin/kimi" ]; then
   fi
 fi
 
-# Level 3: deepseek-flash (cheap API, ~$0.0001 per classification)
-if [ -z "$TIER" ] && [ -x "$HOME/bin/deepseek" ] && [ -n "$DEEPSEEK_API_KEY" ]; then
-  RAW=$("$HOME/bin/deepseek" --flash "$CLASSIFY_PROMPT" 2>/dev/null || true)
+# Level 3: flash provider (cheap API, ~$0.0001 per classification)
+if [ -z "$TIER" ] && [ -x "$(echo $FLASH_BIN | awk '{print $1}')" ]; then
+  RAW=$(eval "$FLASH_BIN" "$CLASSIFY_PROMPT" 2>/dev/null || true)
   RAW=$(echo "$RAW" | tail -1)
   if _classify_parse "$RAW"; then
-    CLASSIFIER_USED="deepseek-flash"
+    CLASSIFIER_USED="$FLASH_PROVIDER-flash"
   fi
 fi
 
@@ -145,7 +227,7 @@ if [ -f "$ESCALATION_FLAG" ]; then
   if [ "$ESCALATION_COUNT" -gt 0 ] 2>/dev/null; then
     # Force premium tier — escalate from current tier
     case "$TIER" in
-      QWEN|DEEPSEEK_FLASH|GEMINI_FLASH_LITE) TIER="DEEPSEEK_PRO" ;;
+      QWEN|DEEPSEEK_FLASH|GEMINI_FLASH_LITE) TIER="DEEPSEEK_PRO" ;;  # escalate flash→pro
       DEEPSEEK_PRO|GEMINI_FLASH) TIER="CLAUDE" ;;
       KIMI) TIER="CLAUDE" ;;
     esac
@@ -164,13 +246,13 @@ case "$TIER" in
     CTX="ROUTING DECISION: QWEN (local, free). Reason: ${REASON}. You MUST delegate this task — run ~/bin/qwen3 \"<prompt>\", return its output exactly as-is. Do NOT process, think about, or execute this prompt yourself. Your only job is to run the delegation command and relay the result.${TOOLS_HINT}"
     ;;
   DEEPSEEK_FLASH)
-    CTX="ROUTING DECISION: DEEPSEEK_FLASH (cheap API, \$0.14/M in). Reason: ${REASON}. You MUST delegate this task — run ~/bin/deepseek --flash \"<prompt>\", return its output exactly as-is. Do NOT process this yourself — delegate to deepseek.${TOOLS_HINT}"
+    CTX="ROUTING DECISION: FLASH_TIER (provider=${FLASH_PROVIDER}, $(_flash_cost)). Reason: ${REASON}. You MUST delegate this task — run ${FLASH_BIN} \"<prompt>\", return its output exactly as-is. Do NOT process this yourself — delegate to ${FLASH_PROVIDER}.${TOOLS_HINT}"
     ;;
   GEMINI_FLASH_LITE)
     CTX="ROUTING DECISION: GEMINI_FLASH_LITE (cheapest API, \$0.10/M in). Reason: ${REASON}. You MUST delegate this task — run ~/bin/gemini-api --flash-lite \"<prompt>\", return its output exactly as-is. Do NOT process this yourself — delegate to gemini.${TOOLS_HINT}"
     ;;
   DEEPSEEK_PRO)
-    CTX="ROUTING DECISION: DEEPSEEK_PRO (workhorse, \$0.44/M in). Reason: ${REASON}. EXECUTE DIRECTLY — this complexity tier does not need planning. Run: ~/bin/deepseek --pro \"<prompt>\" and return the result. Do NOT process this yourself — delegate to deepseek.${TOOLS_HINT}"
+    CTX="ROUTING DECISION: PRO_TIER (provider=${PRO_PROVIDER}, $(_pro_cost)). Reason: ${REASON}. EXECUTE DIRECTLY — this complexity tier does not need planning. Run: ${PRO_BIN} \"<prompt>\" and return the result. Do NOT process this yourself — delegate to ${PRO_PROVIDER}.${TOOLS_HINT}"
     ;;
   GEMINI_FLASH)
     CTX="ROUTING DECISION: GEMINI_FLASH (multimodal, \$0.15/M in). Reason: ${REASON}. Run: ~/bin/gemini-api --flash \"<prompt>\" and return the result. Do NOT process this yourself — delegate to gemini.${TOOLS_HINT}"

--- a/maggy/maggy/api/routes_provider_config.py
+++ b/maggy/maggy/api/routes_provider_config.py
@@ -1,0 +1,76 @@
+"""Provider config REST endpoints — read and update routing.yaml via API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from pydantic import BaseModel
+
+from .auth import check_auth
+from maggy.provider_config import (
+    ProviderConfig,
+    load_provider_config,
+    save_provider_config,
+    SOVEREIGNTY_BLOCKED,
+)
+
+router = APIRouter(prefix="/api/routing/provider-config", tags=["provider-config"])
+
+
+class ProviderConfigUpdate(BaseModel):
+    sovereignty: str | None = None
+    tiers: dict[str, str] | None = None
+
+
+@router.get("")
+async def get_config(
+    request: Request,
+    x_api_key: str | None = Header(None),
+) -> dict:
+    """Return current provider config and available options."""
+    check_auth(request, x_api_key)
+    cfg = load_provider_config()
+    return {
+        "config": cfg.to_dict(),
+        "flash_bin": cfg.flash_bin(),
+        "pro_bin": cfg.pro_bin(),
+        "options": {
+            "sovereignty": ["us", "local", "any"],
+            "flash": ["groq", "together", "ollama", "deepseek"],
+            "pro": ["together", "groq", "ollama", "deepseek"],
+        },
+        "sovereignty_blocked": {k: list(v) for k, v in SOVEREIGNTY_BLOCKED.items()},
+    }
+
+
+@router.post("")
+async def update_config(
+    request: Request,
+    body: ProviderConfigUpdate,
+    x_api_key: str | None = Header(None),
+) -> dict:
+    """Update provider config and persist to ~/.maggy/routing.yaml."""
+    check_auth(request, x_api_key)
+
+    cfg = load_provider_config()
+
+    if body.sovereignty is not None:
+        if body.sovereignty not in ("us", "local", "any"):
+            raise HTTPException(status_code=400, detail="sovereignty must be us, local, or any")
+        cfg.sovereignty = body.sovereignty
+        # Re-init tiers for new sovereignty
+        from maggy.provider_config import _SOVEREIGNTY_TIER_DEFAULTS, _US_FALLBACK
+        defaults = _SOVEREIGNTY_TIER_DEFAULTS.get(cfg.sovereignty, _US_FALLBACK)
+        for tier, provider in defaults.items():
+            cfg.tiers[tier] = provider
+
+    if body.tiers is not None:
+        for tier, provider in body.tiers.items():
+            if not cfg.is_allowed(provider):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Provider '{provider}' is blocked by sovereignty={cfg.sovereignty}",
+                )
+            cfg.tiers[tier] = provider
+
+    save_provider_config(cfg)
+    return {"ok": True, "config": cfg.to_dict()}

--- a/maggy/maggy/api/routes_provider_config.py
+++ b/maggy/maggy/api/routes_provider_config.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 
 from .auth import check_auth
 from maggy.provider_config import (
-    ProviderConfig,
     load_provider_config,
     save_provider_config,
     SOVEREIGNTY_BLOCKED,

--- a/maggy/maggy/main.py
+++ b/maggy/maggy/main.py
@@ -39,6 +39,7 @@ from maggy.api.routes_mesh_admin import router as mesh_admin_router
 from maggy.api.routes_planning import router as planning_router
 from maggy.api.routes_process import router as process_router
 from maggy.api.routes_routing import router as routing_router
+from maggy.api.routes_provider_config import router as provider_config_router
 from maggy.api.routes_blueprints import router as blueprints_router
 from maggy.api.routes_chat import router as chat_router
 from maggy.api.routes_chat_sessions import router as chat_sessions_router
@@ -348,7 +349,7 @@ _ROUTERS = (
     history_router, improve_router, lexon_router,
     mesh_router, mesh_admin_router, models_router, observability_router,
     orchestrator_router, pipeline_router, planning_router, plugins_router,
-    process_router, projects_router, refresh_router, routing_router,
+    process_router, projects_router, provider_config_router, refresh_router, routing_router,
     setup_router, shell_router, skills_router, srooter_router, pr_review_router, system_router, testing_router, users_router,
     ws_mesh_router,
 )

--- a/maggy/maggy/process/model_router.py
+++ b/maggy/maggy/process/model_router.py
@@ -22,6 +22,63 @@ from .model_budget import (
 )
 from .model_tiers import DEFAULT_TIERS
 from .models import ModelTier
+from maggy.provider_config import ProviderConfig, load_provider_config
+
+def _flash_tier(cfg: ProviderConfig) -> ModelTier:
+    """Build the flash tier from provider config."""
+    provider = cfg.flash_provider()
+    model = cfg.flash_model()
+    return ModelTier(
+        name=f"{provider}-flash",
+        provider=provider,
+        model=model,
+        cost_rank=3,
+        complexity_min=0,
+        complexity_max=5,
+        strengths=["boilerplate", "simple_features", "tests", "crud"],
+    )
+
+
+def _pro_tier(cfg: ProviderConfig) -> ModelTier:
+    """Build the pro tier from provider config."""
+    provider = cfg.pro_provider()
+    model = cfg.pro_model()
+    return ModelTier(
+        name=f"{provider}-pro",
+        provider=provider,
+        model=model,
+        cost_rank=4,
+        complexity_min=2,
+        complexity_max=8,
+        strengths=["code_generation", "debugging", "refactor", "feature"],
+    )
+
+
+def build_tiers(cfg: ProviderConfig | None = None) -> list[ModelTier]:
+    """Build the full tier list, substituting flash/pro from provider config."""
+    resolved = cfg or load_provider_config()
+    return [
+        ModelTier(
+            name="local",
+            provider="ollama",
+            model="qwen3-coder:30b-a3b-q8_0",
+            cost_rank=1,
+            complexity_min=0,
+            complexity_max=3,
+            strengths=["formatting", "simple_edits", "crud"],
+        ),
+        ModelTier(
+            name="gemini-flash-lite",
+            provider="google",
+            model="gemini-2.5-flash-lite",
+            cost_rank=2,
+            complexity_min=0,
+            complexity_max=4,
+            strengths=["bulk_extraction", "classification", "cheap_summarization"],
+        ),
+        _flash_tier(resolved),
+        _pro_tier(resolved),
+    ]
 
 
 @dataclass
@@ -50,7 +107,7 @@ def route_task(
         security_sensitive: True for auth/billing/PII tasks
         tiers: Custom tiers (defaults to DEFAULT_TIERS)
     """
-    available = tiers or DEFAULT_TIERS
+    available = tiers or build_tiers()
     primaries = [
         t for t in available if t.role == "primary"
     ]

--- a/maggy/maggy/process/model_router.py
+++ b/maggy/maggy/process/model_router.py
@@ -20,7 +20,6 @@ from .model_budget import (
     MODEL_DAILY_BUDGETS,
     get_model_usage_today,
 )
-from .model_tiers import DEFAULT_TIERS
 from .models import ModelTier
 from maggy.provider_config import ProviderConfig, load_provider_config
 
@@ -78,7 +77,21 @@ def build_tiers(cfg: ProviderConfig | None = None) -> list[ModelTier]:
         ),
         _flash_tier(resolved),
         _pro_tier(resolved),
+        ModelTier(
+            name="claude",
+            provider="anthropic",
+            model="claude-sonnet-4.6",
+            cost_rank=5,
+            complexity_min=6,
+            complexity_max=10,
+            strengths=["complex_reasoning", "security", "architecture"],
+        ),
     ]
+
+
+# DEFAULT_TIERS reflects the active provider config (US sovereignty by default:
+# groq flash + together pro, no China-based providers). Computed once at import.
+DEFAULT_TIERS: list[ModelTier] = build_tiers()
 
 
 @dataclass
@@ -105,7 +118,7 @@ def route_task(
         complexity_score: 0-10 from polyphony scoring
         task_type: "bug", "feature", "refactor", "test", etc.
         security_sensitive: True for auth/billing/PII tasks
-        tiers: Custom tiers (defaults to DEFAULT_TIERS)
+        tiers: Custom tiers (defaults to build_tiers() = provider config)
     """
     available = tiers or build_tiers()
     primaries = [

--- a/maggy/maggy/provider_config.py
+++ b/maggy/maggy/provider_config.py
@@ -1,0 +1,174 @@
+"""Provider config — flex model routing with data sovereignty support.
+
+Loads ~/.maggy/routing.yaml and exposes which bin script to use per tier.
+
+Sovereignty modes:
+  us    — US-based providers only (groq, together, anthropic, openai, google)
+  local — local models only (ollama), no external API calls
+  any   — no restrictions (includes deepseek, kimi, etc.)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from maggy.config import CONFIG_DIR
+
+ROUTING_CONFIG_PATH = CONFIG_DIR / "routing.yaml"
+
+BIN_DIR = Path(os.environ.get("MAGGY_BIN", str(Path.home() / "bin")))
+
+SOVEREIGNTY_BLOCKED: dict[str, set[str]] = {
+    "us": {"deepseek", "kimi", "moonshot"},
+    "local": {"deepseek", "kimi", "moonshot", "groq", "together", "openai", "google", "anthropic"},
+    "any": set(),
+}
+
+_PROVIDER_TO_BIN: dict[str, str] = {
+    "groq": "groq",
+    "together": "together",
+    "ollama": "ollama-coder",
+    "deepseek": "deepseek",
+}
+
+_SOVEREIGNTY_TIER_DEFAULTS: dict[str, dict[str, str]] = {
+    "us": {"flash": "groq", "pro": "together"},
+    "local": {"flash": "ollama", "pro": "ollama"},
+    "any": {"flash": "groq", "pro": "together"},
+}
+
+_US_FALLBACK = {"flash": "groq", "pro": "together"}
+_LOCAL_FALLBACK = {"flash": "ollama", "pro": "ollama"}
+
+
+@dataclass
+class ProviderSettings:
+    model: str
+    api_key_env: str = ""
+    base_url: str = ""
+
+
+_DEFAULT_PROVIDERS: dict[str, ProviderSettings] = {
+    "groq": ProviderSettings(
+        model="llama-3.3-70b-versatile",
+        api_key_env="GROQ_API_KEY",
+    ),
+    "together": ProviderSettings(
+        model="meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+        api_key_env="TOGETHER_API_KEY",
+    ),
+    "ollama": ProviderSettings(
+        model="qwen2.5-coder:72b",
+        base_url="http://localhost:11434",
+    ),
+    "deepseek": ProviderSettings(
+        model="deepseek-chat",
+        api_key_env="DEEPSEEK_API_KEY",
+    ),
+}
+
+
+@dataclass
+class ProviderConfig:
+    sovereignty: str = "us"
+    tiers: dict[str, str] = field(default_factory=dict)
+    providers: dict[str, ProviderSettings] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        defaults = _SOVEREIGNTY_TIER_DEFAULTS.get(self.sovereignty, _US_FALLBACK)
+        for tier, provider in defaults.items():
+            self.tiers.setdefault(tier, provider)
+        for name, settings in _DEFAULT_PROVIDERS.items():
+            self.providers.setdefault(name, settings)
+
+    def is_allowed(self, provider: str) -> bool:
+        blocked = SOVEREIGNTY_BLOCKED.get(self.sovereignty, set())
+        return provider not in blocked
+
+    def _resolve_provider(self, tier: str, fallback_map: dict[str, str]) -> str:
+        provider = self.tiers.get(tier, fallback_map[tier])
+        if not self.is_allowed(provider):
+            provider = fallback_map[tier]
+        return provider
+
+    def flash_bin(self) -> str:
+        if self.sovereignty == "local":
+            return str(BIN_DIR / "ollama-coder")
+        provider = self._resolve_provider("flash", _US_FALLBACK)
+        bin_name = _PROVIDER_TO_BIN.get(provider, provider)
+        return str(BIN_DIR / bin_name)
+
+    def pro_bin(self) -> str:
+        if self.sovereignty == "local":
+            return str(BIN_DIR / "ollama-coder")
+        provider = self._resolve_provider("pro", _US_FALLBACK)
+        bin_name = _PROVIDER_TO_BIN.get(provider, provider)
+        return str(BIN_DIR / bin_name)
+
+    def flash_provider(self) -> str:
+        if self.sovereignty == "local":
+            return "ollama"
+        return self._resolve_provider("flash", _US_FALLBACK)
+
+    def pro_provider(self) -> str:
+        if self.sovereignty == "local":
+            return "ollama"
+        return self._resolve_provider("pro", _US_FALLBACK)
+
+    def flash_model(self) -> str:
+        p = self.providers.get(self.flash_provider())
+        return p.model if p else ""
+
+    def pro_model(self) -> str:
+        p = self.providers.get(self.pro_provider())
+        return p.model if p else ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sovereignty": self.sovereignty,
+            "tiers": dict(self.tiers),
+            "providers": {
+                name: {
+                    "model": s.model,
+                    "api_key_env": s.api_key_env,
+                    "base_url": s.base_url,
+                }
+                for name, s in self.providers.items()
+            },
+        }
+
+
+def load_provider_config(path: Path | None = None) -> ProviderConfig:
+    config_path = Path(path) if path else ROUTING_CONFIG_PATH
+    if not config_path.exists():
+        return ProviderConfig()
+
+    try:
+        raw = yaml.safe_load(config_path.read_text()) or {}
+    except Exception:
+        return ProviderConfig()
+
+    sovereignty = raw.get("sovereignty", "us")
+    tiers = dict(raw.get("tiers", {}))
+
+    providers: dict[str, ProviderSettings] = {}
+    for name, pdata in (raw.get("providers") or {}).items():
+        providers[name] = ProviderSettings(
+            model=pdata.get("model", _DEFAULT_PROVIDERS.get(name, ProviderSettings("")).model),
+            api_key_env=pdata.get("api_key_env", ""),
+            base_url=pdata.get("base_url", ""),
+        )
+
+    cfg = ProviderConfig(sovereignty=sovereignty, tiers=tiers, providers=providers)
+    return cfg
+
+
+def save_provider_config(cfg: ProviderConfig, path: Path | None = None) -> None:
+    config_path = Path(path) if path else ROUTING_CONFIG_PATH
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.dump(cfg.to_dict(), default_flow_style=False))

--- a/maggy/tests/test_deepseek_routing.py
+++ b/maggy/tests/test_deepseek_routing.py
@@ -1,97 +1,119 @@
-"""Tests for DeepSeek V4 model routing integration."""
+"""Tests for flex model routing — flash/pro tiers via provider config."""
 
 from __future__ import annotations
 
 import pytest
 
-from maggy.process.model_router import DEFAULT_TIERS, route_task
+from maggy.process.model_router import DEFAULT_TIERS, build_tiers, route_task
+from maggy.provider_config import ProviderConfig
 
 
-class TestTierStructure:
-    def test_six_tiers_defined(self):
-        assert len(DEFAULT_TIERS) == 6
-
-    def test_tier_names(self):
+class TestDefaultTierStructure:
+    def test_default_tiers_has_local(self):
         names = [t.name for t in DEFAULT_TIERS]
         assert "local" in names
-        assert "deepseek-flash" in names
-        assert "deepseek-pro" in names
-        assert "kimi" in names
-        assert "codex" in names
-        assert "claude" in names
+
+    def test_default_flash_tier_is_groq(self):
+        names = [t.name for t in DEFAULT_TIERS]
+        assert "groq-flash" in names
+
+    def test_default_pro_tier_is_together(self):
+        names = [t.name for t in DEFAULT_TIERS]
+        assert "together-pro" in names
+
+    def test_no_deepseek_in_defaults(self):
+        names = [t.name for t in DEFAULT_TIERS]
+        assert not any("deepseek" in n for n in names)
 
     def test_cost_rank_ordering(self):
         ranks = [t.cost_rank for t in DEFAULT_TIERS]
         assert ranks == sorted(ranks)
 
-    def test_deepseek_flash_is_cheapest_api(self):
-        flash = _tier("deepseek-flash")
-        assert flash.cost_rank == 2
-
-    def test_deepseek_pro_below_kimi(self):
-        pro = _tier("deepseek-pro")
-        kimi = _tier("kimi")
-        assert pro.cost_rank < kimi.cost_rank
-
     def test_claude_is_most_expensive(self):
-        claude = _tier("claude")
-        assert claude.cost_rank == max(
-            t.cost_rank for t in DEFAULT_TIERS
-        )
+        claude = _tier_default("claude")
+        assert claude.cost_rank == max(t.cost_rank for t in DEFAULT_TIERS)
 
 
-class TestDeepSeekRouting:
+class TestBuildTiersFlexConfig:
+    def test_groq_flash_config(self):
+        cfg = ProviderConfig(sovereignty="us", tiers={"flash": "groq", "pro": "together"})
+        tiers = build_tiers(cfg)
+        names = [t.name for t in tiers]
+        assert "groq-flash" in names
+
+    def test_together_pro_config(self):
+        cfg = ProviderConfig(sovereignty="us", tiers={"flash": "groq", "pro": "together"})
+        tiers = build_tiers(cfg)
+        names = [t.name for t in tiers]
+        assert "together-pro" in names
+
+    def test_ollama_flash_config(self):
+        cfg = ProviderConfig(sovereignty="local", tiers={"flash": "ollama", "pro": "ollama"})
+        tiers = build_tiers(cfg)
+        flash = next(t for t in tiers if t.cost_rank == 3)
+        assert flash.provider == "ollama"
+
+    def test_local_sovereignty_uses_ollama_for_both(self):
+        cfg = ProviderConfig(sovereignty="local")
+        tiers = build_tiers(cfg)
+        flash = next(t for t in tiers if t.cost_rank == 3)
+        pro = next(t for t in tiers if t.cost_rank == 4)
+        assert flash.provider == "ollama"
+        assert pro.provider == "ollama"
+
+    def test_deepseek_blocked_in_us_sovereignty(self):
+        cfg = ProviderConfig(sovereignty="us", tiers={"flash": "deepseek", "pro": "deepseek"})
+        tiers = build_tiers(cfg)
+        providers = [t.provider for t in tiers]
+        assert "deepseek" not in providers
+
+
+class TestRouting:
     def test_low_complexity_routes_to_local(self):
         r = route_task(complexity_score=1)
         assert r.primary.name == "local"
 
-    def test_medium_low_routes_to_deepseek_flash(self):
+    def test_medium_low_routes_to_flash_tier(self):
         r = route_task(complexity_score=4)
-        assert r.primary.cost_rank <= 2
+        assert r.primary.cost_rank <= 3
 
-    def test_medium_routes_to_deepseek_pro(self):
+    def test_medium_routes_to_pro_tier(self):
         r = route_task(complexity_score=6)
-        assert r.primary.name in (
-            "deepseek-pro", "deepseek-flash",
-        )
+        assert r.primary.cost_rank >= 3
 
     def test_high_complexity_routes_premium(self):
         r = route_task(complexity_score=9)
         assert r.primary.cost_rank >= 3
 
     def test_security_skips_cheap_tiers(self):
-        r = route_task(
-            complexity_score=3, task_type="security",
-        )
+        r = route_task(complexity_score=3, task_type="security")
         assert r.primary.cost_rank >= 3
 
-    def test_deepseek_flash_in_fallback_chain(self):
+    def test_flash_tier_in_fallback_chain(self):
         r = route_task(complexity_score=1)
-        assert "deepseek-flash" in r.fallback_chain
+        assert len(r.fallback_chain) > 0
 
 
-class TestDeepSeekProviders:
-    def test_flash_provider(self):
-        flash = _tier("deepseek-flash")
-        assert flash.provider == "deepseek"
+class TestProviderInfo:
+    def test_default_flash_provider_is_groq(self):
+        flash = _tier_default("groq-flash")
+        assert flash.provider == "groq"
 
-    def test_pro_provider(self):
-        pro = _tier("deepseek-pro")
-        assert pro.provider == "deepseek"
+    def test_default_pro_provider_is_together(self):
+        pro = _tier_default("together-pro")
+        assert pro.provider == "together"
 
-
-class TestDeepSeekStrengths:
-    def test_flash_strengths(self):
-        flash = _tier("deepseek-flash")
+    def test_flash_strengths_include_boilerplate(self):
+        flash = _tier_default("groq-flash")
         assert "boilerplate" in flash.strengths
 
-    def test_pro_strengths(self):
-        pro = _tier("deepseek-pro")
+    def test_pro_strengths_include_code_generation(self):
+        pro = _tier_default("together-pro")
         assert "code_generation" in pro.strengths
 
 
-def _tier(name: str):
+def _tier_default(name: str):
     for t in DEFAULT_TIERS:
         if t.name == name:
             return t
-    raise ValueError(f"Tier {name!r} not found")
+    raise ValueError(f"Tier {name!r} not found in DEFAULT_TIERS")

--- a/maggy/tests/test_provider_config.py
+++ b/maggy/tests/test_provider_config.py
@@ -1,0 +1,181 @@
+"""Tests for ProviderConfig — flex routing + data sovereignty."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from maggy.provider_config import (
+    ProviderConfig,
+    load_provider_config,
+    SOVEREIGNTY_BLOCKED,
+)
+
+
+class TestDefaults:
+    def test_default_sovereignty_is_us(self):
+        cfg = ProviderConfig()
+        assert cfg.sovereignty == "us"
+
+    def test_default_flash_is_groq(self):
+        cfg = ProviderConfig()
+        assert cfg.tiers["flash"] == "groq"
+
+    def test_default_pro_is_together(self):
+        cfg = ProviderConfig()
+        assert cfg.tiers["pro"] == "together"
+
+    def test_flash_bin_points_to_groq(self):
+        cfg = ProviderConfig()
+        assert cfg.flash_bin().endswith("groq")
+
+    def test_pro_bin_points_to_together(self):
+        cfg = ProviderConfig()
+        assert cfg.pro_bin().endswith("together")
+
+
+class TestSovereigntyUS:
+    def test_us_blocks_deepseek(self):
+        cfg = ProviderConfig(sovereignty="us")
+        assert not cfg.is_allowed("deepseek")
+
+    def test_us_blocks_kimi(self):
+        cfg = ProviderConfig(sovereignty="us")
+        assert not cfg.is_allowed("kimi")
+
+    def test_us_allows_groq(self):
+        cfg = ProviderConfig(sovereignty="us")
+        assert cfg.is_allowed("groq")
+
+    def test_us_allows_together(self):
+        cfg = ProviderConfig(sovereignty="us")
+        assert cfg.is_allowed("together")
+
+    def test_us_allows_anthropic(self):
+        cfg = ProviderConfig(sovereignty="us")
+        assert cfg.is_allowed("anthropic")
+
+    def test_us_allows_ollama(self):
+        cfg = ProviderConfig(sovereignty="us")
+        assert cfg.is_allowed("ollama")
+
+
+class TestSovereigntyLocal:
+    def test_local_blocks_deepseek(self):
+        cfg = ProviderConfig(sovereignty="local")
+        assert not cfg.is_allowed("deepseek")
+
+    def test_local_blocks_groq(self):
+        cfg = ProviderConfig(sovereignty="local")
+        assert not cfg.is_allowed("groq")
+
+    def test_local_blocks_together(self):
+        cfg = ProviderConfig(sovereignty="local")
+        assert not cfg.is_allowed("together")
+
+    def test_local_blocks_anthropic(self):
+        cfg = ProviderConfig(sovereignty="local")
+        assert not cfg.is_allowed("anthropic")
+
+    def test_local_allows_ollama(self):
+        cfg = ProviderConfig(sovereignty="local")
+        assert cfg.is_allowed("ollama")
+
+    def test_local_flash_bin_is_ollama(self):
+        cfg = ProviderConfig(sovereignty="local")
+        assert cfg.flash_bin().endswith("ollama-coder")
+
+    def test_local_pro_bin_is_ollama(self):
+        cfg = ProviderConfig(sovereignty="local")
+        assert cfg.pro_bin().endswith("ollama-coder")
+
+
+class TestSovereigntyAny:
+    def test_any_allows_deepseek(self):
+        cfg = ProviderConfig(sovereignty="any")
+        assert cfg.is_allowed("deepseek")
+
+    def test_any_allows_kimi(self):
+        cfg = ProviderConfig(sovereignty="any")
+        assert cfg.is_allowed("kimi")
+
+    def test_any_allows_groq(self):
+        cfg = ProviderConfig(sovereignty="any")
+        assert cfg.is_allowed("groq")
+
+
+class TestLoadFromYaml:
+    def test_load_sovereignty_local(self, tmp_path):
+        f = tmp_path / "routing.yaml"
+        f.write_text(textwrap.dedent("""
+            sovereignty: local
+            tiers:
+              flash: ollama
+              pro: ollama
+        """))
+        cfg = load_provider_config(f)
+        assert cfg.sovereignty == "local"
+        assert cfg.tiers["flash"] == "ollama"
+
+    def test_load_sovereignty_us(self, tmp_path):
+        f = tmp_path / "routing.yaml"
+        f.write_text(textwrap.dedent("""
+            sovereignty: us
+            tiers:
+              flash: groq
+              pro: together
+        """))
+        cfg = load_provider_config(f)
+        assert cfg.sovereignty == "us"
+        assert cfg.tiers["pro"] == "together"
+
+    def test_load_custom_provider_model(self, tmp_path):
+        f = tmp_path / "routing.yaml"
+        f.write_text(textwrap.dedent("""
+            sovereignty: us
+            tiers:
+              flash: groq
+              pro: together
+            providers:
+              groq:
+                model: llama-3.1-70b-versatile
+                api_key_env: GROQ_API_KEY
+        """))
+        cfg = load_provider_config(f)
+        assert cfg.providers["groq"].model == "llama-3.1-70b-versatile"
+
+    def test_load_missing_file_returns_defaults(self, tmp_path):
+        cfg = load_provider_config(tmp_path / "nonexistent.yaml")
+        assert cfg.sovereignty == "us"
+        assert cfg.tiers["flash"] == "groq"
+
+    def test_load_partial_yaml_uses_defaults_for_missing(self, tmp_path):
+        f = tmp_path / "routing.yaml"
+        f.write_text("sovereignty: us\n")
+        cfg = load_provider_config(f)
+        assert cfg.tiers["flash"] == "groq"
+        assert cfg.tiers["pro"] == "together"
+
+
+class TestBinResolution:
+    def test_flash_deepseek_bin(self):
+        cfg = ProviderConfig(sovereignty="any", tiers={"flash": "deepseek", "pro": "together"})
+        assert cfg.flash_bin().endswith("deepseek")
+
+    def test_pro_ollama_bin(self):
+        cfg = ProviderConfig(sovereignty="any", tiers={"flash": "groq", "pro": "ollama"})
+        assert cfg.pro_bin().endswith("ollama-coder")
+
+    def test_sovereignty_local_overrides_tier_setting(self):
+        # Even if tiers say groq, local sovereignty forces ollama
+        cfg = ProviderConfig(sovereignty="local", tiers={"flash": "groq", "pro": "together"})
+        assert cfg.flash_bin().endswith("ollama-coder")
+        assert cfg.pro_bin().endswith("ollama-coder")
+
+    def test_sovereignty_us_overrides_deepseek_tier(self):
+        # US sovereignty + deepseek tier → falls back to groq
+        cfg = ProviderConfig(sovereignty="us", tiers={"flash": "deepseek", "pro": "deepseek"})
+        assert not cfg.flash_bin().endswith("deepseek")
+        assert not cfg.pro_bin().endswith("deepseek")

--- a/maggy/tests/test_routing_config.py
+++ b/maggy/tests/test_routing_config.py
@@ -99,27 +99,29 @@ class TestToDict:
 
 
 class TestDefaultTiers:
-    """Default model tiers: no GPT, codex is primary."""
+    """Default model tiers: no GPT, US-sovereignty default (groq/together/claude)."""
 
     def test_no_gpt_in_defaults(self):
         from maggy.process.model_router import DEFAULT_TIERS
         names = [t.name for t in DEFAULT_TIERS]
         assert "gpt" not in names
 
-    def test_codex_is_primary(self):
+    def test_claude_is_premium(self):
+        # US-sovereignty default: claude is the most-expensive (premium) tier
         from maggy.process.model_router import DEFAULT_TIERS
-        codex = [t for t in DEFAULT_TIERS if t.name == "codex"]
-        assert len(codex) == 1
-        assert codex[0].role == "primary"
+        claude = [t for t in DEFAULT_TIERS if t.name == "claude"]
+        assert len(claude) == 1
+        assert claude[0].cost_rank == max(t.cost_rank for t in DEFAULT_TIERS)
 
-    def test_codex_handles_complex(self):
+    def test_premium_handles_complex(self):
         from maggy.process.model_router import DEFAULT_TIERS
-        codex = [t for t in DEFAULT_TIERS if t.name == "codex"][0]
-        assert codex.complexity_max >= 8
+        claude = [t for t in DEFAULT_TIERS if t.name == "claude"][0]
+        assert claude.complexity_max >= 8
 
-    def test_local_kimi_handle_simple(self):
+    def test_local_and_flash_handle_simple(self):
+        # local (ollama) and the flash tier cover simple work
         from maggy.process.model_router import DEFAULT_TIERS
         local = [t for t in DEFAULT_TIERS if t.name == "local"][0]
-        kimi = [t for t in DEFAULT_TIERS if t.name == "kimi"][0]
+        flash = [t for t in DEFAULT_TIERS if t.name.endswith("-flash")][0]
         assert local.complexity_max <= 5
-        assert kimi.complexity_max <= 5
+        assert flash.complexity_max <= 5

--- a/templates/routing.yaml
+++ b/templates/routing.yaml
@@ -1,0 +1,61 @@
+# Maggy Provider Config — copy to ~/.maggy/routing.yaml and customize
+#
+# sovereignty:
+#   us    — US-based providers only (groq, together, anthropic, openai, google)
+#           Blocks: deepseek, kimi, moonshot
+#   local — local models only (ollama). No external API calls, no data leaves machine.
+#   any   — no restrictions (use any provider including deepseek, kimi, etc.)
+#
+sovereignty: us
+
+# tiers — which provider handles each complexity tier
+# flash: simple code, boilerplate, CRUD, single-file changes
+# pro:   multi-file features, refactors, debugging, test suites
+#
+# Options:
+#   groq      — Groq API, Llama 3.3 70B, fast + cheap (~$0.05/M). US-based.
+#   together  — Together AI, Llama 3.1 405B, near-Claude quality (~$3.50/M). US-based.
+#   ollama    — Local Ollama, qwen2.5-coder:72b, free + private. Needs GPU for best results.
+#   deepseek  — DeepSeek API, strong coding model (~$0.44/M). China-based.
+#
+tiers:
+  flash: groq       # groq | together | ollama | deepseek
+  pro: together     # together | groq | ollama | deepseek
+
+# providers — model and auth config per provider
+# Override only what you need; defaults are filled in automatically.
+#
+providers:
+  groq:
+    model: llama-3.3-70b-versatile
+    api_key_env: GROQ_API_KEY
+
+  together:
+    model: meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo
+    api_key_env: TOGETHER_API_KEY
+
+  ollama:
+    model: qwen2.5-coder:72b
+    base_url: http://localhost:11434   # override if Ollama runs elsewhere
+
+  deepseek:
+    model: deepseek-chat
+    api_key_env: DEEPSEEK_API_KEY
+
+# ── Quick presets ────────────────────────────────────────────────────────────
+#
+# Full US (recommended for data sovereignty):
+#   sovereignty: us
+#   tiers: { flash: groq, pro: together }
+#
+# Fully local (air-gapped / maximum privacy):
+#   sovereignty: local
+#   tiers: { flash: ollama, pro: ollama }
+#
+# Best quality, US-only (close to Claude for pro tier):
+#   sovereignty: us
+#   tiers: { flash: groq, pro: together }
+#
+# No restrictions (include DeepSeek for cheaper pro tier):
+#   sovereignty: any
+#   tiers: { flash: groq, pro: deepseek }


### PR DESCRIPTION
Rebased and reconciled version of #26 by @sseshachala (original commits preserved).

**What it adds:** flex provider routing with data-sovereignty modes (us/local/any) — replaces the hardcoded DeepSeek default with config-driven flash/pro providers (groq + together by default, ollama for air-gapped), enforced at the routing + hook level. New `bin/{groq,together,ollama-coder}`, `provider_config.py`, `/api/routing/provider-config`, `templates/routing.yaml`.

**Reconciliation with current main** (see the merge commit): kept all current routers + added provider_config; grafted `build_tiers()` onto main's routing; completed the tier ladder with a claude premium tier (the PR's `build_tiers` was missing it); `DEFAULT_TIERS = build_tiers()`; updated default-tier tests to the new US ladder.

**Validation:** PR's 51 tests pass. Full suite: **33 failed / 2173 passed** vs main's baseline **38 / 2131** (net −5 failures, +42 passing). App builds, ruff clean. Remaining failures pre-exist on main (deepseek/blast routing tests, unrelated).

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new command-line tools for sending prompts to multiple AI providers.
  * Added configurable provider routing with sovereignty modes and editable defaults.
  * Added API endpoints to view and update routing settings.
* **Documentation**
  * Added new guides explaining provider routing, usage, and model comparisons.
  * Added a starter routing configuration template.
* **Bug Fixes**
  * Routing now adapts to the selected provider settings instead of using fixed defaults.
* **Tests**
  * Expanded coverage for routing behavior, configuration loading, and provider selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->