### PR TITLE
fix(hooks): harden bootstrap PreToolUse hooks (valid-JSON-or-nothing)

### DIFF
--- a/hooks/icpg-inject-context
+++ b/hooks/icpg-inject-context
@@ -52,13 +52,14 @@ if [ -n "$DRIFT" ] && [ "$DRIFT" != "No drift detected" ]; then
   CTX="$CTX\n\n⚠️ DRIFT: ${DRIFT}"
 fi
 
-# Inject as additional context
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "additionalContext": $(echo "$CTX" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" 2>/dev/null || echo "\"$CTX\"")
-  }
-}
-EOF
+# Inject as additional context. Build the whole payload in Python so the output
+# is always valid JSON or nothing — never a malformed fallback string.
+CTX="$CTX" python3 -c "
+import os, json
+ctx = os.environ.get('CTX') or ''
+if ctx.strip():
+    print(json.dumps({'hookSpecificOutput': {
+        'hookEventName': 'PreToolUse',
+        'additionalContext': ctx}}))
+" 2>/dev/null
 exit 0

--- a/hooks/icpg-record-intent
+++ b/hooks/icpg-record-intent
@@ -20,13 +20,13 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-# Extract file path and check for existing ReasonNodes
-FILE_PATH=$(echo "$TOOL_INPUT" | python3 -c "
-import sys, json
+# Extract file path (via env var — never double-read stdin, never crash)
+FILE_PATH=$(TOOL_INPUT="$TOOL_INPUT" python3 -c "
+import os, json
 try:
-    d = json.loads(sys.stdin) if sys.stdin.read() else {}
-    print(d.get('file_path', d.get('path', '')))
-except:
+    d = json.loads(os.environ.get('TOOL_INPUT') or '{}')
+    print((d.get('file_path') or d.get('path') or '') if isinstance(d, dict) else '')
+except Exception:
     pass" 2>/dev/null | head -1)
 
 [ -z "$FILE_PATH" ] && exit 0
@@ -44,17 +44,25 @@ fi
 # Check if ReasonNode already exists for this file
 EXISTING=$($ICPG_CMD query intent "$FILE_PATH" 2>/dev/null)
 if [ -n "$EXISTING" ]; then
-  # Already has intent — inject as context, don't create new
-  cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "permissionDecisionReason": "Existing iCPG intents found for this file",
-    "updatedInput": $(echo "$TOOL_INPUT" | jq -c '. + {"icpg_context": "'"$(echo "$EXISTING" | head -3 | tr '\n' ' ')"'"}' 2>/dev/null || echo "$TOOL_INPUT")
-  }
-}
-EOF
+  # Already has intent — inject as context. Build the whole payload in Python so
+  # an intent containing quotes/newlines can NEVER produce malformed JSON (which
+  # Claude Code would surface as a hook error) or silently drop the context.
+  ICPG_EXISTING="$EXISTING" TOOL_INPUT="$TOOL_INPUT" python3 -c "
+import os, json
+try:
+    ti = json.loads(os.environ.get('TOOL_INPUT') or '{}')
+    if not isinstance(ti, dict):
+        ti = {}
+    ctx = ' '.join((os.environ.get('ICPG_EXISTING') or '').splitlines()[:3]).strip()
+    if ctx:
+        ti = dict(ti, icpg_context=ctx)
+    print(json.dumps({'hookSpecificOutput': {
+        'hookEventName': 'PreToolUse',
+        'permissionDecision': 'allow',
+        'permissionDecisionReason': 'Existing iCPG intents found for this file',
+        'updatedInput': ti}}))
+except Exception:
+    pass" 2>/dev/null
   exit 0
 fi
 

--- a/tests/test_hook_robustness.py
+++ b/tests/test_hook_robustness.py
@@ -1,0 +1,53 @@
+"""Robustness guardrail for the bootstrap PreToolUse hooks.
+
+Every PreToolUse hook MUST, for any input (empty, malformed, adversarial):
+  1. exit 0 (fail-open — never block or error the session), and
+  2. write valid JSON or nothing to stdout (a malformed payload is surfaced by
+     Claude Code as a "hook error").
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parents[1] / "hooks"
+PRETOOL_HOOKS = ["icpg-record-intent", "icpg-inject-context", "mid-task-escalation"]
+
+PAYLOADS = {
+    "empty": "",
+    "malformed": "{not valid json",
+    "edit_missing_file": '{"tool_name":"Edit","tool_input":{"file_path":"/no/such/f.py"}}',
+    "edit_special_chars": '{"tool_name":"Edit","tool_input":'
+    '{"file_path":"/tmp/a\\"b.py","new_string":"x\\ny"}}',
+    "non_edit_tool": '{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"}}',
+    "null_input": '{"tool_name":"Edit","tool_input":null}',
+}
+
+
+def _run(hook: str, stdin: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(HOOKS_DIR / hook)],
+        input=stdin, capture_output=True, text=True, timeout=15,
+    )
+
+
+@pytest.mark.parametrize("hook", PRETOOL_HOOKS)
+@pytest.mark.parametrize("name", list(PAYLOADS))
+def test_hook_exits_zero_and_emits_valid_json_or_nothing(hook: str, name: str) -> None:
+    r = _run(hook, PAYLOADS[name])
+    assert r.returncode == 0, f"{hook} exited {r.returncode} on {name}: {r.stderr}"
+    out = r.stdout.strip()
+    if out:
+        json.loads(out)  # must parse — malformed JSON would raise
+
+
+def test_record_intent_no_crash_on_double_read_regression() -> None:
+    # Regression for the json.loads(sys.stdin) bug that silently disabled the
+    # hook: a well-formed Edit payload must be processed without a Python trace.
+    r = _run("icpg-record-intent", PAYLOADS["edit_missing_file"])
+    assert r.returncode == 0
+    assert "Traceback" not in r.stderr


### PR DESCRIPTION
## What

Hardens the bootstrap-installed PreToolUse hooks so they can never emit malformed JSON (which Claude Code surfaces as a "hook error") and never silently misbehave.

- **`icpg-record-intent`**: fix `json.loads(sys.stdin)` bug — it read stdin twice and passed a file object to `json.loads`, so the hook *silently never recorded intent*. Now extracts `file_path` via an env var.
- Build all hook JSON output in Python (`json.dumps`) instead of shell interpolation, so an intent containing quotes/newlines can't produce malformed JSON or silently drop the context.
- **`icpg-inject-context`**: same treatment; dropped the fragile shell fallback.

## Tests

`tests/test_hook_robustness.py` (19 cases): every PreToolUse hook must **exit 0** and emit **valid JSON or nothing** for empty / malformed / null / special-char / non-Edit payloads, plus a regression that `icpg-record-intent` no longer crashes.

## Notes

Already synced to the local `~/.claude/hooks/` (active on this machine); this PR persists it in the repo for future installs and other machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JohuQy42xdpx1DKa3FCtQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook handling for empty, malformed, or missing input.
  * Ensured generated hook output is valid JSON when context is available.
  * Safely preserves existing intent text, including quotes and line breaks.
  * Prevented errors when editing files that do not exist.

* **Tests**
  * Added robustness coverage for malformed payloads and non-edit inputs.
  * Added regression coverage to verify hooks exit cleanly without tracebacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->