### PR TITLE
docs: document Polyphony parallel development in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,24 @@ Pick the model you "follow" once with `/model-config` — Maggy, the route-task 
 
 ---
 
+## Parallel Development (Polyphony)
+
+Run several agents at once — each in its own Docker/OrbStack container with a full git clone on its own branch, so concurrent work never collides on files or branches.
+
+- **Auto-isolation** — a second Claude Code session in the same project automatically provisions its own workspace (via the `polyphony-auto-isolate` hook). No setup.
+- **`/spawn-team`** — spawns a coordinated TDD agent team; container-isolated by default when Docker + the `polyphony` CLI are present, with a graceful fallback to native parallel agents.
+
+```bash
+polyphony init                 # one-time: create ~/.polyphony/ config
+polyphony spawn "add auth"     # create + route a task to an agent
+polyphony status               # running agents / task states
+polyphony cleanup              # remove completed workspaces
+```
+
+From Claude Code: `/polyphony-init`, `/polyphony-spawn`, `/polyphony-status`. Requires Docker or OrbStack. Full design: [Polyphony spec](maggy/docs/polyphony-spec.md).
+
+---
+
 ## Telos: Testing Beyond TDD
 
 Standard TDD tells you if your code passes tests. Telos tells you if your code fulfills its *intent*.

--- a/maggy/README.md
+++ b/maggy/README.md
@@ -61,6 +61,29 @@ Every message gets a semantic blast score (1-10), then routes to the cheapest ca
 
 The router learns from outcomes — successful tasks reinforce the routing decision.
 
+## Parallel Development (Polyphony)
+
+Run multiple agents concurrently without conflicts. Each agent session runs in its
+own Docker/OrbStack container with a **full git clone on its own branch** — six
+layers: work source → orchestrator → router → identity broker → workspace manager
+→ worker runtime.
+
+- **Auto-isolation** — a second Claude Code session in the same project
+  automatically provisions its own workspace (no setup).
+- **Container mode is the default** when Docker + the `polyphony` CLI are present;
+  falls back to native parallel agents otherwise.
+
+```bash
+polyphony init                 # one-time: create ~/.polyphony/ config
+polyphony spawn "add auth"     # create + route a task to an agent
+polyphony status               # running agents / task states
+polyphony cleanup              # remove completed workspaces
+```
+
+From Claude Code: `/polyphony-init`, `/polyphony-spawn`, `/polyphony-status`, or
+`/spawn-team` (a coordinated TDD team, container-isolated by default). Requires
+Docker or OrbStack. Full spec: [Polyphony spec](./docs/polyphony-spec.md).
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
Polyphony (container-isolated parallel agents) was only a one-line mention in each README. Adds a proper **Parallel Development (Polyphony)** section to root + Maggy READMEs: the `polyphony init/spawn/status/cleanup` CLI, the `/polyphony-*` and `/spawn-team` commands, auto-isolation, container mode, and the Docker/OrbStack requirement. Every command and link verified against the code (docs-only, 41 insertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JohuQy42xdpx1DKa3FCtQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running multiple development agents concurrently with isolated containers and branches.
  * Documented automatic isolation behavior for additional sessions, including fallback when container tooling is unavailable.
  * Added examples for initializing, spawning, monitoring, and cleaning up parallel workstreams.
  * Linked to the Polyphony specification for further details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->