### PR TITLE
feat(rules): require a CHANGELOG entry in every commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [6.58.0] - 2026-08-18
+
+### Changelog discipline — every commit ships a CHANGELOG entry
+
+#### Added
+- **`rules/changelog.md`** — new conditional rule installed to `~/.claude/rules/`:
+  every commit that changes behaviour, config, docs, or dependencies MUST update a
+  `CHANGELOG.md` in the same commit (Keep a Changelog format, one entry per commit,
+  staged with the code). Formatting-only and comment-typo changes are exempt.
+- **`/initialize-project` seeds the rule into every project** — the generated
+  `CLAUDE.md` now carries a "Changelog — Required for Every Commit" section, and
+  init seeds a root `CHANGELOG.md` with a `[Unreleased]` block so the discipline
+  holds from the first commit.
+
+#### Changed
+- Bootstrap `CLAUDE.md` Git Workflow now requires a `CHANGELOG.md` update in the
+  same commit as the code.
+
+---
+
 ## [6.57.0] - 2026-07-11
 
 ### GPT-5.6 council support, GLM executor, `/route-eval`, key/routing config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@
 - Write clear, concise commit messages
 - One logical change per commit
 - Run tests before committing
+- **Update `CHANGELOG.md` in the same commit** — every behaviour/config/docs/deps
+  change ships a changelog entry (see `rules/changelog.md`). No commit without one.
 
 ## Tools & Frameworks
 

--- a/commands/initialize-project.md
+++ b/commands/initialize-project.md
@@ -1027,6 +1027,18 @@ This project uses MCP-based code graph for optimized code navigation.
 ~/.claude/install-graph-tools.sh --codeql
 ```
 
+## Changelog — Required for Every Commit
+
+Every commit that changes behaviour, config, docs, or dependencies MUST update
+`CHANGELOG.md` in the **same commit**. No feature, fix, or refactor lands without
+a changelog line. See `.claude/rules/changelog.md`.
+
+- Keep a root `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com)
+  with an `## [Unreleased]` section (Added / Changed / Fixed / Removed / Security).
+- One entry per commit, staged together with the code.
+- Exempt: pure formatting, comment typos, changes to the changelog itself.
+- On release: rename `[Unreleased]` to the version + date, start a fresh block.
+
 ## Project-Specific Patterns
 [Any specific patterns for this project]
 ```
@@ -1066,6 +1078,35 @@ Development workflow enforced by claude-bootstrap skills and ADR gate.
 - Related: _project_specs/overview.md
 ADRINIT
     echo "✓ Created docs/adr/0001-project-init.md"
+fi
+```
+
+#### Seed CHANGELOG.md
+
+```bash
+# Every project gets a changelog; every commit updates it (see rules/changelog.md)
+if [ ! -f "CHANGELOG.md" ]; then
+    cat > CHANGELOG.md << 'CHANGELOG'
+# Changelog
+
+All notable changes to this project are documented here.
+Format based on [Keep a Changelog](https://keepachangelog.com);
+this project adheres to [Semantic Versioning](https://semver.org).
+
+## [Unreleased]
+
+### Added
+- Project initialized with claude-bootstrap.
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Security
+CHANGELOG
+    echo "✓ Created CHANGELOG.md"
 fi
 ```
 

--- a/rules/changelog.md
+++ b/rules/changelog.md
@@ -1,0 +1,42 @@
+---
+description: Changelog discipline — every commit ships with a CHANGELOG entry
+---
+
+## Changelog — Required for Every Commit
+
+Every commit that changes behaviour, config, docs, or dependencies MUST update a
+`CHANGELOG.md` in the same commit. No feature, fix, or refactor lands without a
+changelog line.
+
+### Rules
+
+1. **Keep a `CHANGELOG.md`.** If none exists at the repo root (or in the package
+   you're touching), create one following [Keep a Changelog](https://keepachangelog.com):
+   ```markdown
+   # Changelog
+
+   ## [Unreleased]
+   ### Added
+   ### Changed
+   ### Fixed
+   ```
+2. **One entry per commit.** Add a line under the matching heading
+   (Added / Changed / Fixed / Removed / Security) describing *what* changed and
+   *why* — the same logical change the commit captures.
+3. **Same commit, not a follow-up.** The changelog edit is staged and committed
+   together with the code. A commit with code changes and no changelog change is
+   incomplete.
+4. **Monorepos:** update the `CHANGELOG.md` closest to the changed files, and the
+   root `CHANGELOG.md` if the change is user-visible at the top level.
+5. **Version on release.** When cutting a release, rename `[Unreleased]` to the
+   new version + date and start a fresh `[Unreleased]` block.
+
+### Exempt (no changelog needed)
+
+Pure whitespace/formatting, typo fixes in comments, and changes to the changelog
+itself. When in doubt, add the entry.
+
+### Before committing
+
+- [ ] `CHANGELOG.md` has an entry for this change
+- [ ] The entry is staged in the same commit as the code


### PR DESCRIPTION
## What
Adds a **changelog-discipline rule** to the harness and seeds it into every project scaffolded by `/initialize-project`.

## Why
Commits were landing without changelog updates. This makes "every commit ships a CHANGELOG entry" a first-class, installed rule so it holds across all projects using maggy/claude-bootstrap.

## How
- **`rules/changelog.md`** — new conditional rule; `install.sh` already globs `rules/*.md` into `~/.claude/rules/`, so it ships automatically. Every behaviour/config/docs/deps change updates `CHANGELOG.md` in the same commit (Keep a Changelog format, one entry per commit). Formatting-only and comment-typo changes are exempt.
- **`/initialize-project`** — generated `CLAUDE.md` gains a "Changelog — Required for Every Commit" section; init seeds a root `CHANGELOG.md` with an `[Unreleased]` block.
- **Bootstrap `CLAUDE.md`** — Git Workflow now requires the changelog update inline.
- **`CHANGELOG.md`** — `[6.58.0]` entry (dogfoods the rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JohuQy42xdpx1DKa3FCtQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog guidelines covering required updates, formatting, exemptions, release versioning, and pre-commit checks.
  * Updated project setup and Git workflow documentation to enforce changelog maintenance.
  * New projects now receive a Keep a Changelog-formatted file with an **Unreleased** section and standard categories.
  * Added a changelog entry documenting the new process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->